### PR TITLE
Add desktop local service launchers

### DIFF
--- a/Pizza Logs HQ/00 Inbox/START HERE.md
+++ b/Pizza Logs HQ/00 Inbox/START HERE.md
@@ -59,7 +59,8 @@ Formal details: `docs/parser-contract.md`.
 - Admin diagnostics and admin upload history
 - Guild roster cache for PizzaWarriors/Lordaeron
 - Warmane gear cache, GearScoreLite display, AzerothCore item metadata
-- Browser userscripts for roster, gear, and portrait imports
+- Browser userscripts for roster and gear imports
+- Desktop start/stop launchers for the local web, parser, and PostgreSQL services
 - Cinematic intro and responsive page polish
 
 ## Files To Know

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -17,6 +17,10 @@
 - Local Git executable fallback: `C:\Program Files\Git\cmd\git.exe`
 - GitHub CLI executable: `C:\Program Files\GitHub CLI\gh.exe`
 - Parser correctness remains the highest-risk area.
+- Local desktop launchers:
+  - `C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd`
+  - `C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd`
+- The repeating `PizzaLogsLocalTestServer` scheduled task is disabled; use the desktop launchers instead.
 
 ## Current Implementation Snapshot
 
@@ -46,6 +50,17 @@
 - Added local install buttons and URL fields on the admin gear and guild roster panels.
 - Local gear and roster scripts still run on Warmane Armory pages, but they post imports into the laptop dev server instead of production.
 - Local portrait script is compatibility-only and does not mutate Pizza Logs, Warmane, or modelviewer pages.
+
+## Local Service Launcher Changes This Session
+
+- Added repo-backed Desktop launcher templates:
+  - `scripts/desktop/Start Pizza Logs Local.cmd`
+  - `scripts/desktop/Stop Pizza Logs Local.cmd`
+- Copied those launchers to Neil's Desktop root.
+- `Start Pizza Logs Local.cmd` starts PostgreSQL if needed, parser on `127.0.0.1:8000`, and Next.js on `127.0.0.1:3001`.
+- `Stop Pizza Logs Local.cmd` stops the Pizza Logs web/parser ports and tries to stop the local PostgreSQL service. If Windows blocks PostgreSQL service control, run the stop launcher as administrator.
+- Both scripts keep the old repeating `PizzaLogsLocalTestServer` scheduled task disabled.
+- Validation note: non-elevated stop successfully stops web/parser; Windows denied stopping `postgresql-x64-16`, so full three-service stop requires running the stop launcher as administrator.
 
 ## Recent Documentation Audit Changes
 
@@ -84,6 +99,10 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 | Local `3001` gear userscript endpoint | 200, contained local origin and local script name |
 | Local `3001` roster userscript endpoint | 200, contained local origin and local script name |
 | Local `3001` portrait userscript endpoint | 200, contained local origin, version `0.6.0`, deprecation text, and no active DOM/GM/canvas code |
+| Desktop launchers copied | `Start Pizza Logs Local.cmd` and `Stop Pizza Logs Local.cmd` exist on the Desktop root |
+| `PizzaLogsLocalTestServer` scheduled task | Disabled |
+| `scripts/stop-local-test-server.ps1 -DisableScheduledTask -StopPostgres` | Stopped web/parser; PostgreSQL stop denied without elevation as expected |
+| `scripts/start-local-test-server.ps1 -DisableScheduledTask` | Restarted web/parser with PostgreSQL running |
 
 ## Local Server Recovery
 

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-Retiring rendered portrait capture and standardizing player avatars on class icons through draft PR #8.
+Retiring rendered portrait capture, standardizing player avatars on class icons, and replacing the repeating local scheduled task with Desktop start/stop launchers.
 
 ## Current Branch Rule
 
@@ -21,6 +21,8 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Verified local endpoints on `http://127.0.0.1:3001`, including the no-op portrait compatibility endpoint.
 - Validation passed locally with bundled runtimes: focused userscript/admin/profile tests, lint, type-check, and production build.
 - Recovered the local `3001` dev server after a stale `.next` cache caused `Cannot find module './5611.js'`.
+- Added Desktop launchers for starting/stopping the local web, parser, and PostgreSQL services.
+- Disabled the repeating `PizzaLogsLocalTestServer` scheduled task that caused recurring PowerShell popups.
 
 ## Next Actions
 
@@ -36,6 +38,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Branch publication | DONE | Commit and push `codex-dev` for draft PR #8 |
 | PR creation | DONE | Draft PR #8 is open; connector still lacks PR write permission |
 | Human review | NEXT | Neil reviews class-icon behavior after PR #8 merges |
+| Replace repeating local task | DONE | Use Desktop `Start Pizza Logs Local.cmd` / `Stop Pizza Logs Local.cmd` |
 
 ## Open Follow-Ups
 
@@ -44,6 +47,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.
 - Absorbs remain future parser work.
 - If the laptop port changes from `3001`, add matching local roster/gear userscript variants or update the local constants.
+- If the Desktop launcher copies drift, update `scripts/desktop/*.cmd` and copy them back to `C:\Users\neil_\OneDrive\Desktop`.
 
 ## Reference
 

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -37,6 +37,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Local dev DB outage crashed pages | Public/admin pages catch DB connection failures and show warnings |
 | Local 3001 server missing `.next` chunks | Stopped stale Next process, removed generated `.next`, restarted `PizzaLogsLocalTestServer`, and verified local page/scripts return 200 |
 | Portrait userscript stayed on class icons or caused hydration warnings | Retired active portrait capture and standardized avatars on class icons; old userscript URLs now serve no-op compatibility updates |
+| Repeating local scheduled task caused recurring PowerShell popups | Disabled `PizzaLogsLocalTestServer`; added Desktop start/stop launchers for web, parser, and PostgreSQL |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -180,11 +180,22 @@ Docker compose is available for a local production-style stack:
 docker compose up --build
 ```
 
-On Neil's Windows desktop, these helpers manage the long-running local test stack on `127.0.0.1:3001` and parser on `127.0.0.1:8000`:
+On Neil's Windows desktop, the preferred local workflow is the two Desktop launchers:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-local-test-server.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\stop-local-test-server.ps1
+C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd
+C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd
+```
+
+The launchers call repo scripts that manage the local web app on `127.0.0.1:3001`, the parser on `127.0.0.1:8000`, and the local PostgreSQL service. They also keep the old repeating `PizzaLogsLocalTestServer` scheduled task disabled so PowerShell does not pop up every few minutes.
+
+If Windows blocks stopping PostgreSQL, right-click `Stop Pizza Logs Local.cmd` and choose **Run as administrator**. The web and parser processes stop without elevation.
+
+The underlying scripts can be run directly:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\start-local-test-server.ps1 -DisableScheduledTask
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\stop-local-test-server.ps1 -DisableScheduledTask -StopPostgres
 ```
 
 ## Testing And Validation

--- a/scripts/desktop/Start Pizza Logs Local.cmd
+++ b/scripts/desktop/Start Pizza Logs Local.cmd
@@ -1,0 +1,8 @@
+@echo off
+set "REPO=C:\Users\neil_\OneDrive\Desktop\PizzaLogs"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\start-local-test-server.ps1" -DisableScheduledTask
+if errorlevel 1 (
+  echo.
+  echo Start failed. See %REPO%\.next-local-test-server.log for details.
+  pause
+)

--- a/scripts/desktop/Stop Pizza Logs Local.cmd
+++ b/scripts/desktop/Stop Pizza Logs Local.cmd
@@ -1,0 +1,8 @@
+@echo off
+set "REPO=C:\Users\neil_\OneDrive\Desktop\PizzaLogs"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\stop-local-test-server.ps1" -DisableScheduledTask -StopPostgres
+if errorlevel 1 (
+  echo.
+  echo Stop had errors. If PostgreSQL did not stop, right-click this script and choose Run as administrator.
+  pause
+)

--- a/scripts/start-local-test-server.ps1
+++ b/scripts/start-local-test-server.ps1
@@ -1,6 +1,7 @@
 param(
   [int]$WebPort = 3001,
-  [int]$ParserPort = 8000
+  [int]$ParserPort = 8000,
+  [switch]$DisableScheduledTask
 )
 
 $ErrorActionPreference = "Stop"
@@ -87,6 +88,15 @@ $PythonPath = Resolve-Executable `
 
 Write-Log "Launcher starting. Repo=$RepoRoot WebPort=$WebPort ParserPort=$ParserPort"
 
+if ($DisableScheduledTask) {
+  $task = Get-ScheduledTask -TaskName "PizzaLogsLocalTestServer" -ErrorAction SilentlyContinue
+  if ($task -and $task.State -ne "Disabled") {
+    Disable-ScheduledTask -TaskName "PizzaLogsLocalTestServer" | Out-Null
+    Write-Log "Disabled scheduled task PizzaLogsLocalTestServer."
+    Write-Output "Disabled scheduled task PizzaLogsLocalTestServer."
+  }
+}
+
 $postgres = Get-Service -Name "postgresql*" -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($postgres) {
   if ($postgres.Status -ne "Running") {
@@ -140,6 +150,13 @@ Write-Log "Health results: parser=$parserOk web=$webOk"
 
 if (-not $parserOk -or -not $webOk) {
   exit 1
+}
+
+Write-Output "Pizza Logs local services are running."
+Write-Output "Web:    http://127.0.0.1:$WebPort"
+Write-Output "Parser: http://127.0.0.1:$ParserPort/health"
+if ($postgres) {
+  Write-Output "DB:     PostgreSQL service $($postgres.Name) status=$((Get-Service -Name $postgres.Name).Status)"
 }
 
 exit 0

--- a/scripts/stop-local-test-server.ps1
+++ b/scripts/stop-local-test-server.ps1
@@ -1,8 +1,21 @@
 param(
-  [int[]]$Ports = @(3001, 8000)
+  [int[]]$Ports = @(3001, 8000),
+  [switch]$StopPostgres,
+  [switch]$DisableScheduledTask
 )
 
 $ErrorActionPreference = "Stop"
+$hadStopError = $false
+
+if ($DisableScheduledTask) {
+  $task = Get-ScheduledTask -TaskName "PizzaLogsLocalTestServer" -ErrorAction SilentlyContinue
+  if ($task -and $task.State -ne "Disabled") {
+    Disable-ScheduledTask -TaskName "PizzaLogsLocalTestServer" | Out-Null
+    Write-Output "Disabled scheduled task PizzaLogsLocalTestServer."
+  } elseif ($task) {
+    Write-Output "Scheduled task PizzaLogsLocalTestServer is already disabled."
+  }
+}
 
 $connections = Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | Where-Object {
   $_.LocalPort -in $Ports
@@ -26,4 +39,26 @@ foreach ($processId in $processIds) {
   } else {
     Write-Output "Skipped pid=$processId because it does not look like a Pizza Logs server"
   }
+}
+
+if ($StopPostgres) {
+  $postgres = Get-Service -Name "postgresql*" -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $postgres) {
+    Write-Output "No PostgreSQL service named postgresql* was found."
+  } elseif ($postgres.Status -eq "Running") {
+    try {
+      Stop-Service -Name $postgres.Name -ErrorAction Stop
+      Write-Output "Stopped PostgreSQL service $($postgres.Name)"
+    } catch {
+      Write-Warning "Could not stop PostgreSQL service $($postgres.Name): $($_.Exception.Message)"
+      Write-Warning "Right-click the desktop stop script and choose Run as administrator if Windows blocks service control."
+      $hadStopError = $true
+    }
+  } else {
+    Write-Output "PostgreSQL service $($postgres.Name) is already $($postgres.Status)."
+  }
+}
+
+if ($hadStopError) {
+  exit 1
 }


### PR DESCRIPTION
## Summary
- add Desktop launcher templates for starting and stopping the local Pizza Logs stack
- update start/stop scripts to keep the old repeating PizzaLogsLocalTestServer scheduled task disabled
- stop script now handles web/parser ports and attempts PostgreSQL stop, with an administrator-rights warning when Windows blocks service control
- document the Desktop launcher workflow in README and the Obsidian vault

## Verification
- copied Start Pizza Logs Local.cmd and Stop Pizza Logs Local.cmd to C:\Users\neil_\OneDrive\Desktop
- disabled PizzaLogsLocalTestServer scheduled task
- ran stop script: web/parser stopped; PostgreSQL stop was denied without elevation as expected
- ran start script: web/parser restarted with PostgreSQL running
- verified http://127.0.0.1:3001/ returns 200 and contains Pizza Logs
- verified http://127.0.0.1:8000/health returns 200