### PR TITLE
[codex] harden combat log parser flow

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Decision Log.md
+++ b/Pizza Logs HQ/02 Build Log/Decision Log.md
@@ -71,7 +71,7 @@
 
 **Decision:** Do not infer heroic difficulty from boss HP or total-damage thresholds.
 **Why:** Warmane evidence is inconsistent and HP/damage ratios are too noisy.
-**Status:** Still valid. Superseded detail: the parser now uses encounter marker difficulty when present, heroic-only marker spells where reliable, and session normalization for supported cases. Some Warmane pulls still cannot be proven heroic from logs alone.
+**Status:** Still valid. Superseded detail: the parser now uses encounter marker difficulty when present, heroic-only marker spells where reliable, and only narrow session normalization that cannot bucket a normal fallback attempt under heroic. Some Warmane pulls still cannot be proven heroic from logs alone.
 
 ---
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -34,47 +34,28 @@
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
+- Parser tokenization and combat math are now split into small Python modules under `parser/` so line parsing and metric extraction can be tested independently.
+- Parser warnings now report malformed combat-log lines instead of silently skipping them.
+- `/parse`, `/parse-debug`, and `/parse-stream` reject unsupported upload filenames before parsing.
+- Explicit `ENCOUNTER_START` / `ENCOUNTER_END` windows are preserved even when they are shorter than the heuristic minimum-event floor.
+- Difficulty normalization is evidence-first: non-Gunship normal-looking pulls are not promoted to heroic solely because a nearby pull in the same upload was heroic.
 
-## Class Icon Avatar Cleanup This Session
+## Parser Refactor This Session
 
-- Retired active Warmane/Wowhead/Zamimg portrait capture and standardized player avatars on built-in class icons.
-- Removed the portrait install UI from `/admin`.
-- Removed stale `portraitUrl` plumbing from player profiles, player lists, session pages, and roster rows.
-- Replaced stale portrait parsing helpers with `lib/class-icons.ts`.
-- Kept the old `/api/player-portraits/...` userscript URLs as no-op compatibility updates so existing Tampermonkey installs can self-update to harmless code.
-- Bumped the no-op compatibility portrait userscript to `0.6.0`.
-- Added local install endpoints:
-  - `http://127.0.0.1:3001/api/admin/armory-gear/userscript.local.user.js`
-  - `http://127.0.0.1:3001/api/admin/guild-roster/userscript.local.user.js`
-  - `http://127.0.0.1:3001/api/player-portraits/userscript.local.user.js`
-- Added local install buttons and URL fields on the admin gear and guild roster panels.
-- Local gear and roster scripts still run on Warmane Armory pages, but they post imports into the laptop dev server instead of production.
-- Local portrait script is compatibility-only and does not mutate Pizza Logs, Warmane, or modelviewer pages.
-
-## Local Service Launcher Changes This Session
-
-- Added repo-backed Desktop launcher templates:
-  - `scripts/desktop/Start Pizza Logs Local.cmd`
-  - `scripts/desktop/Stop Pizza Logs Local.cmd`
-- Copied those launchers to Neil's Desktop root.
-- `Start Pizza Logs Local.cmd` starts PostgreSQL if needed, parser on `127.0.0.1:8000`, and Next.js on `127.0.0.1:3001`.
-- `Stop Pizza Logs Local.cmd` stops the Pizza Logs web/parser ports and tries to stop the local PostgreSQL service. If Windows blocks PostgreSQL service control, run the stop launcher as administrator.
-- Both scripts keep the old repeating `PizzaLogsLocalTestServer` scheduled task disabled.
-- Validation note: non-elevated stop successfully stops web/parser; Windows denied stopping `postgresql-x64-16`, so full three-service stop requires running the stop launcher as administrator.
-
-## Recent Documentation Audit Changes
-
-- Rewrote root README, contributor workflow, security policy, branch workflow docs, and review checklist around the current `codex-dev -> PR -> main` process.
-- Removed duplicate or historical-only docs:
-  - blank vault inbox capture note;
-  - completed cinematic Superpowers spec and plan;
-  - duplicate AI prompt/skill reference notes;
-  - old growth/business note;
-  - separate backlog and technical-debt docs now consolidated into `Feature Status`.
-- Updated vault architecture, deployment, security, parser, current-focus, and known-issues notes to match current code.
-- Corrected stale direct-`main` deploy language.
-- Corrected stale claims that heroic and Gunship behavior are completely undetectable.
-- Documented open repo issues found during audit: upload lacks hard server-side size enforcement, and some env/example variables had drifted from actual code usage.
+- Added `docs/parser-audit.md` before changing parser behavior.
+- Audited the current upload path from `app/api/upload/route.ts` through parser `/parse-stream`, database persistence, player/session stats, and existing parser tests.
+- Studied local reference checkouts of `Ridepad/uwu-logs` and `bkader/Skada-WoTLK`; the audit cites the exact files/functions that influenced the refactor.
+- Added `parser/combat_log_events.py` for timestamp parsing, CSV-safe combat-log tokenization, skipped-line classification, and normalized line objects.
+- Added `parser/combat_metrics.py` for damage/healing field extraction and explicit encounter/session damage formulas.
+- Refactored `parser/parser_core.py` to use those helpers while preserving existing production-facing result shapes.
+- Kept stored encounter damage compatible with existing Pizza Logs behavior: `amount - overkill - absorbed`.
+- Kept full-session actor `sessionDamage` compatible with existing behavior: `amount + absorbed`.
+- Kept healing effective by default: gross heal minus overheal; absorbs remain separate future work.
+- Added parser warnings for malformed/truncated combat-log lines.
+- Fixed short explicit marker encounters being discarded by heuristic floors.
+- Fixed heroic-session bleed where a later normal kill could be promoted to heroic without direct evidence.
+- Added `/parse-stream` filename validation to match `/parse` and `/parse-debug`.
+- Updated README, parser contract docs, parser architecture notes, security notes, decision log, current-focus, and known-issues docs.
 
 ## Verification This Session
 
@@ -82,37 +63,19 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 
 | Check | Result |
 |---|---|
-| `tests/armory-gear-client-scripts.test.ts` | Passed |
-| `tests/guild-roster-client-scripts.test.ts` | Passed |
-| `tests/player-portrait-client-scripts.test.ts` | Passed |
-| `tests/gear-import-bookmarklet.test.ts` | Passed |
-| `tests/guild-roster-admin-panel.test.ts` | Passed |
-| `tests/guild-roster-table-render.test.ts` | Passed with JSX-aware `ts-node` options |
-| `tests/local-userscript-routes.test.ts` | Passed |
-| `tests/class-icons.test.ts` | Passed |
-| `tests/player-profile.test.ts` | Passed |
-| `tests/session-avatar-source.test.ts` | Passed |
+| `python -m pytest tests/ -v` from `parser/` | Passed, `133 passed, 1 warning` |
 | ESLint via bundled Node | Passed |
 | TypeScript `tsc --noEmit` via bundled Node | Passed |
 | Next production build via bundled Node | Passed |
-| Local `3001` app root | 200, contained `Pizza Logs` |
-| Local `3001` gear userscript endpoint | 200, contained local origin and local script name |
-| Local `3001` roster userscript endpoint | 200, contained local origin and local script name |
-| Local `3001` portrait userscript endpoint | 200, contained local origin, version `0.6.0`, deprecation text, and no active DOM/GM/canvas code |
-| Desktop launchers copied | `Start Pizza Logs Local.cmd` and `Stop Pizza Logs Local.cmd` exist on the Desktop root |
-| `PizzaLogsLocalTestServer` scheduled task | Disabled |
-| `scripts/stop-local-test-server.ps1 -DisableScheduledTask -StopPostgres` | Stopped web/parser; PostgreSQL stop denied without elevation as expected |
-| `scripts/start-local-test-server.ps1 -DisableScheduledTask` | Restarted web/parser with PostgreSQL running |
+| `git diff --check` | Passed |
 
-## Local Server Recovery
+## Remaining Risks
 
-- A runtime error appeared on `http://127.0.0.1:3001`: `Cannot find module './5611.js'`.
-- Root cause was a mixed `.next` cache: the running dev server loaded a webpack runtime expecting chunks at `.next\server\5611.js`, while the actual chunks were under `.next\server\chunks\5611.js`.
-- Likely trigger: running a production `next build` while the long-running local dev server was still active.
-- Recovery performed: stopped the stale Next process, removed only the generated `.next` folder, restarted the existing `PizzaLogsLocalTestServer` scheduled task, and verified `/` plus the local gear userscript endpoint returned 200.
-- After the hydration fix build, the same generated-cache pattern briefly recurred with a missing `vendor-chunks/lucide-react.js`. Recovery was the same: fully stop repo Next processes, remove only generated `.next`, restart `PizzaLogsLocalTestServer`, then verify `/` and local userscript endpoints return 200.
-- During the class-icon cleanup, `next build` first compiled then hit stale `.next` route module state for admin API routes. Removing generated `.next`, rerunning the build, then restarting the local test server manually through `scripts/start-local-test-server.ps1` restored `http://127.0.0.1:3001`.
+- Absorbs are still not implemented as healing; Skada treats them separately.
+- Some Warmane heroic/Gunship evidence is not present in every log, so ambiguous attempts stay conservative rather than guessed heroic.
+- Useful damage is documented and test-covered through existing encounter rules, but needs more encounter-specific exclusions over time.
+- Upload route still lacks hard server-side size enforcement; this remains the highest practical upload-flow follow-up.
 
 ## Exact Next Step
 
-Push the updated `codex-dev` commit into draft PR #8. After merge, no portrait userscript update is needed for normal use because class icons are built into the app; existing old portrait userscript installs can be removed, or allowed to auto-update to the no-op compatibility script.
+Push the parser refactor commit to `origin/codex-dev`, then open or update the PR into `main` for review. Do not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-Retiring rendered portrait capture, standardizing player avatars on class icons, and replacing the repeating local scheduled task with Desktop start/stop launchers.
+Parser reliability for uploaded `WoWCombatLog.txt` files, with Skada-aligned metric documentation, better malformed-line handling, and evidence-first difficulty segmentation.
 
 ## Current Branch Rule
 
@@ -10,35 +10,36 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
-- Retired active rendered portrait capture because class icons are the supported avatar path.
-- Removed portrait install links and URL fields from `/admin`.
-- Simplified `PlayerAvatar` to use class icons with initials fallback; removed `portraitUrl` props and data attributes from player, session, and roster screens.
-- Replaced the old portrait userscript body with a `0.6.0` no-op compatibility update that tells existing users they can uninstall it.
-- Added local userscript builders and install endpoints for gear and guild roster imports.
-- Kept the old portrait userscript endpoint only for existing install compatibility.
-- Added local install links and URL fields on `/admin` for browser-assisted local roster and gear imports.
-- Kept production userscript URLs unchanged for Railway production.
-- Verified local endpoints on `http://127.0.0.1:3001`, including the no-op portrait compatibility endpoint.
-- Validation passed locally with bundled runtimes: focused userscript/admin/profile tests, lint, type-check, and production build.
-- Recovered the local `3001` dev server after a stale `.next` cache caused `Cannot find module './5611.js'`.
-- Added Desktop launchers for starting/stopping the local web, parser, and PostgreSQL services.
-- Disabled the repeating `PizzaLogsLocalTestServer` scheduled task that caused recurring PowerShell popups.
+- Created `docs/parser-audit.md` before changing parser behavior.
+- Audited parser and upload code paths, including `/parse-stream`, parser core, persistence contracts, docs, and current tests.
+- Studied local checkouts of `Ridepad/uwu-logs` and `bkader/Skada-WoTLK`; audit notes cite the relevant files/functions.
+- Split combat-log tokenization into `parser/combat_log_events.py`.
+- Split damage/healing extraction formulas into `parser/combat_metrics.py`.
+- Refactored `parser/parser_core.py` to use those helpers while preserving existing result shapes.
+- Added skipped-line accounting and aggregate parser warnings for malformed/truncated combat-log lines.
+- Added `/parse-stream` filename validation for `.txt` and `.log` uploads.
+- Preserved short explicit marker encounters that previously could be discarded by heuristic minimum-event filtering.
+- Narrowed session difficulty normalization so heroic wipes do not promote a later normal kill unless there is direct evidence.
+- Added focused parser tests for tokenization, damage, healing, malformed lines, explicit markers, heroic-to-normal fallback, and stream upload validation.
+- Updated README, parser contract docs, parser architecture notes, security checklist, decision log, and known issues.
+- Validation passed: full parser pytest suite, TypeScript type-check, ESLint, Next production build, and `git diff --check`.
 
 ## Next Actions
 
 | Task | Status | Notes |
 |---|---|---|
-| Add local gear userscript | DONE | `http://127.0.0.1:3001/api/admin/armory-gear/userscript.local.user.js` |
-| Add local roster userscript | DONE | `http://127.0.0.1:3001/api/admin/guild-roster/userscript.local.user.js` |
-| Retire portrait capture | DONE | Active script replaced by no-op compatibility update |
-| Keep class-icon avatars | DONE | `PlayerAvatar` renders class icons or initials only |
-| Remove portrait admin UI | DONE | `/admin` only advertises roster and gear browser imports |
-| Run validation | DONE | Focused tests, lint, type-check, build, and live local endpoint checks passed |
-| Recover local 3001 server | DONE | Cleared generated `.next`, restarted `PizzaLogsLocalTestServer`, verified `/` and local endpoints return 200 |
-| Branch publication | DONE | Commit and push `codex-dev` for draft PR #8 |
-| PR creation | DONE | Draft PR #8 is open; connector still lacks PR write permission |
-| Human review | NEXT | Neil reviews class-icon behavior after PR #8 merges |
-| Replace repeating local task | DONE | Use Desktop `Start Pizza Logs Local.cmd` / `Stop Pizza Logs Local.cmd` |
+| Parser audit doc | DONE | `docs/parser-audit.md` |
+| Tokenizer module | DONE | `parser/combat_log_events.py` |
+| Metric extraction module | DONE | `parser/combat_metrics.py` |
+| Parser core refactor | DONE | Existing response shape preserved |
+| Malformed-line reporting | DONE | Parser warning plus skipped-line counters |
+| Stream upload validation | DONE | `/parse-stream` now validates filename extension |
+| Explicit marker regression | DONE | Marker encounters bypass heuristic minimum-event floor |
+| Heroic-to-normal regression | DONE | Later normal kills stay normal without direct heroic evidence |
+| Documentation update | DONE | README, parser contract, vault parser docs, security, decision log, known issues |
+| Validation | DONE | Parser tests, type-check, lint, build, diff check |
+| Branch publication | NEXT | Commit and push `codex-dev` |
+| PR update | NEXT | Open or update PR into `main` after push |
 
 ## Open Follow-Ups
 
@@ -46,6 +47,8 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.
 - Absorbs remain future parser work.
+- Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.
+- Add anonymized larger upload fixtures if Neil can provide safe samples.
 - If the laptop port changes from `3001`, add matching local roster/gear userscript variants or update the local constants.
 - If the Desktop launcher copies drift, update `scripts/desktop/*.cmd` and copy them back to `C:\Users\neil_\OneDrive\Desktop`.
 

--- a/Pizza Logs HQ/04 Architecture/Parser Deep Dive.md
+++ b/Pizza Logs HQ/04 Architecture/Parser Deep Dive.md
@@ -31,8 +31,8 @@ Warmane logs often have missing or misleading encounter markers, so the heuristi
 
 - Encounter marker difficulty IDs map to `10N`, `25N`, `10H`, or `25H` when present.
 - Warmane may report heroic pulls as normal, so heroic marker spells are checked even when `ENCOUNTER_START` exists.
-- Session normalization can promote same-session `25N` encounters to `25H` when the session has reliable heroic evidence.
-- Some encounters do not expose enough evidence and remain normal unless session evidence proves otherwise.
+- Session normalization is intentionally narrow: Gunship can inherit heroic evidence, but normal-looking non-Gunship attempts are not promoted just because another pull in the session was heroic.
+- Some encounters do not expose enough evidence and remain normal rather than guessing from unrelated pulls.
 
 ## Damage Events
 
@@ -65,7 +65,8 @@ parts[12] absorbed
 parts[13] critical
 ```
 
-Effective damage subtracts overkill and absorbed amounts.
+Stored encounter damage subtracts overkill and absorbed amounts. Full-session
+`sessionDamage` counts `amount + absorbed` as total player output across the log.
 
 ## Healing Events
 
@@ -111,6 +112,10 @@ Skada has no `ignored_spells.heal`; every `SPELL_HEAL` and `SPELL_PERIODIC_HEAL`
 ## Performance
 
 - Lines are parsed with Python's CSV module.
+- Raw line tokenizing lives in `parser/combat_log_events.py`.
+- Damage/healing field extraction lives in `parser/combat_metrics.py`.
+- Malformed non-blank lines are counted and returned as aggregate parser warnings.
 - Boss-name sets are cached on parser initialization.
 - `/parse-stream` emits SSE progress while parsing and while Next.js writes DB rows.
+- `/parse-stream` rejects unsupported filename extensions before writing temp files.
 - Parser tests live under `parser/tests/`.

--- a/Pizza Logs HQ/07 Security/Security Checklist.md
+++ b/Pizza Logs HQ/07 Security/Security Checklist.md
@@ -12,7 +12,7 @@
 | SQL injection | Low risk | Prisma parameterizes DB queries |
 | XSS | Low risk | React escapes output; avoid adding raw HTML rendering |
 | Secrets in repo | Guarded | `.env*`, logs, caches, uploads, and combat logs are ignored |
-| Upload file type validation | Partial | Client accepts `.txt`/`.log`; parser `/parse-stream` needs stricter server-side validation |
+| Upload file type validation | Improved | Parser `/parse`, `/parse-debug`, and `/parse-stream` reject non-`.txt`/`.log` filenames; `/api/upload` still forwards accepted browser uploads |
 | Upload size enforcement | Open | UI says 1 GB, but `/api/upload` does not enforce a hard server-side limit |
 | Rate limiting | Open | No app-level upload rate limiting |
 
@@ -26,7 +26,7 @@
 ## Priority Fixes
 
 1. Enforce upload size while streaming or before forwarding to the parser.
-2. Add server-side upload file type/content checks for `/api/upload` and parser `/parse-stream`.
+2. Add deeper content sniffing if filename validation proves insufficient.
 3. Decide whether Railway-level rate limiting is sufficient.
 
 ## Threat Model

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -13,7 +13,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Absorbs are not implemented | Disc priest contribution can be lower than Skada combined healing+absorbs views | Future parser work based on Skada `Absorbs.lua`; keep separate from healing done |
 | Role detection is rough | Hybrids/self-healing classes can be mislabeled; tanks are not inferred | Replace upload-time heal/damage ratio with better class/spec/combat evidence |
 | Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway | Supported path is browser-assisted userscripts and cached DB snapshots |
-| Some heroic/Gunship difficulty evidence is absent | Certain pulls cannot be classified perfectly from logs alone | Use marker/session evidence where available; document uncertainty |
+| Some heroic/Gunship difficulty evidence is absent | Certain pulls cannot be classified perfectly from logs alone | Use direct marker evidence first; keep normal-looking non-Gunship fallback attempts normal; document uncertainty |
 | Orphaned pets can remain unmatched | Small DPS mismatches when pets were active before log start | Keep Skada-aligned owner remap when summon evidence exists |
 
 ## Resolved Reference
@@ -38,6 +38,10 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Local 3001 server missing `.next` chunks | Stopped stale Next process, removed generated `.next`, restarted `PizzaLogsLocalTestServer`, and verified local page/scripts return 200 |
 | Portrait userscript stayed on class icons or caused hydration warnings | Retired active portrait capture and standardized avatars on class icons; old userscript URLs now serve no-op compatibility updates |
 | Repeating local scheduled task caused recurring PowerShell popups | Disabled `PizzaLogsLocalTestServer`; added Desktop start/stop launchers for web, parser, and PostgreSQL |
+| Parser silently skipped malformed lines | Added tokenizer-level skipped-line accounting and aggregate parser warnings |
+| Parser `/parse-stream` accepted unsupported filenames | Added `.txt`/`.log` filename validation before temp-file handling |
+| Short explicit marker pulls could be discarded | Marker-based encounters now bypass the heuristic minimum-event floor |
+| Heroic wipes could promote later normal kills | Non-Gunship `25N` pulls no longer inherit heroic solely from same-session evidence |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ Key rules:
 
 - Damage events match Skada `Damage.lua`: `SPELL_DAMAGE`, `SWING_DAMAGE`, `RANGE_DAMAGE`, `SPELL_PERIODIC_DAMAGE`, `DAMAGE_SHIELD`, `DAMAGE_SPLIT`, and `SPELL_BUILDING_DAMAGE`.
 - Healing events match Skada `Healing.lua`: `SPELL_HEAL` and `SPELL_PERIODIC_HEAL`.
+- Stored encounter damage is the app's useful/effective leaderboard value: `amount - overkill - absorbed`; full-session `sessionDamage` counts `amount + absorbed`.
 - Effective healing is `max(0, gross - overheal)`.
 - `SPELL_HEAL_ABSORBED` is not healing done in Skada.
 - `SWING_DAMAGE` uses shifted indexes because it has no spell fields.
 - KILL duration uses boss death time, not the last post-kill event.
 - Gunship kill detection has a Warmane crew-death override.
-- Heroic detection uses marker spells and session normalization where the log evidence supports it. Some encounters remain impossible to classify perfectly from Warmane logs alone.
+- Heroic detection uses encounter marker IDs, reliable marker spells, and narrow session normalization only where it cannot cross-contaminate normal fallback attempts. Some encounters remain impossible to classify perfectly from Warmane logs alone.
+- Malformed combat-log lines are counted and returned as parser warnings instead of crashing uploads.
 
 ## Player, Gear, And Roster Data
 
@@ -253,7 +255,7 @@ Production requirements:
 app/                 Next.js pages and API routes
 components/          UI, upload, meters, player gear, roster widgets
 lib/                 Prisma client, schemas, parser contracts, Warmane/item helpers
-parser/              FastAPI parser service and pytest suite
+parser/              FastAPI parser service, parser modules, and pytest suite
 parser/tests/fixtures/
                      Combat-log fixture inputs and expected outputs
 prisma/              Schema, migrations, and seed script

--- a/docs/parser-audit.md
+++ b/docs/parser-audit.md
@@ -1,0 +1,129 @@
+# Parser Audit
+
+Date: 2026-05-05
+
+Scope: `parser/parser_core.py`, `parser/main.py`, `app/api/upload/route.ts`, parser tests, parser-facing Zod schemas, Prisma upload/encounter/participant persistence, and UI paths that read saved parser metrics.
+
+## Current Parser Flow
+
+1. Browser uploads `WoWCombatLog.txt` to `POST /api/upload`.
+2. Next.js streams the multipart body to `PARSER_SERVICE_URL/parse-stream`.
+3. `parser/main.py` writes the upload to a temp file, hashes it, counts lines, then runs `CombatLogParser.parse_file`.
+4. `CombatLogParser._iter_lines` tokenizes timestamped lines into `(ts_str, parts, ts)`.
+5. `CombatLogParser._segment_encounters` chooses one of two paths:
+   - `ENCOUNTER_START` / `ENCOUNTER_END` markers if any marker is found.
+   - Boss-name heuristic windows when no markers are present.
+6. The same pass builds global pet-owner hints from `SPELL_SUMMON` and player-to-pet healing.
+7. `CombatLogParser._aggregate_segment` infers boss, difficulty, outcome, actor totals, spell breakdowns, target breakdowns, duration, and fingerprint.
+8. `app/api/upload/route.ts` validates the parser payload, deduplicates by file hash and encounter fingerprint, writes uploads, encounters, participants, and milestones, then marks the upload `DONE`.
+
+Current storage keeps one encounter damage field: `totalDamage`. In practice it is the parser's useful/effective encounter damage convention, not a separate raw damage field.
+
+## Reference Findings
+
+Skada-WoTLK is the primary source of truth for in-game totals:
+
+- `Skada/Modules/Damage.lua:54` (`log_damage`) records actor and set damage, tracks absorbed damage separately, and records overkill as a separate value.
+- `Skada/Modules/Damage.lua:680` (`RegisterForCL`) registers `DAMAGE_SHIELD`, `DAMAGE_SPLIT`, `RANGE_DAMAGE`, `SPELL_BUILDING_DAMAGE`, `SPELL_DAMAGE`, `SPELL_PERIODIC_DAMAGE`, and `SWING_DAMAGE`.
+- `Skada/Core/Prototypes.lua:98` / `:109` define damage and DPS; useful damage subtracts recorded overkill.
+- `Skada/Modules/Damage.lua:1010` defines the "Useful Damage" mode as a separate view.
+- `Skada/Modules/Healing.lua:45` (`log_heal`) records effective healing as `max(0, amount - overheal)` and stores overheal separately.
+- `Skada/Modules/Healing.lua:397` registers only `SPELL_HEAL` and `SPELL_PERIODIC_HEAL` for healing done.
+- `Skada/Core/Tables.lua:61` shows the healing ignore table is commented out, including `Judgement of Light`.
+- `Skada/Core/Prototypes.lua:204` / `:209` define healing and HPS from the set duration.
+
+uwu-logs is useful for upload-oriented architecture and WotLK segmentation:
+
+- `logs_fight_separator.py:111` / `:225` separates boss-line collection from pull slicing.
+- `logs_fight_separator.py:151` refines fight endings using boss death, overkill, and aura removal evidence.
+- `logs_fight_separator.py:277` uses boss-specific idle windows instead of one universal timeout.
+- `logs_fight_separator.py:371` dumps boss lines by GUID before computing encounter windows.
+- `logs_check_difficulty.py:244` / `:258` detects difficulty from boss spell IDs.
+- `logs_check_difficulty.py:278` / `:287` uses overkill and boss death evidence for kill detection.
+- `logs_dmg_useful.py:31` keeps encounter-specific useful-target tables.
+- `logs_dmg_heals.py:98` parses damage, healing, damage taken, and total healing in one aggregate pass, then `:138` / `:162` remap pets to owners.
+
+## Known Weaknesses
+
+- `parser_core.py` is one large module; line tokenizing, event math, pet ownership, segmentation, difficulty, outcome, aggregation, and serialization-facing model construction are tightly coupled.
+- Explicit `ENCOUNTER_START` / `ENCOUNTER_END` segments currently pass through the same minimum event floor as heuristic segments. Explicit marker windows should be trusted even for short wipes or partial logs.
+- Once any encounter marker appears, the file uses marker mode globally. Mixed marker/no-marker logs can miss later heuristic-only encounters.
+- Session difficulty normalization promotes every `25N` encounter in a session to `25H` after any confirmed `25H` encounter. That can incorrectly bucket a later normal attempt after heroic wipes.
+- The parser silently skips malformed lines. Unsupported combat events are still intentionally ignored, but malformed input should be counted and surfaced as parser warnings so upload results are explainable.
+- `totalDamage` and "useful damage" are not modeled separately in the app schema. A schema migration may be warranted later, but changing leaderboard semantics in this refactor would be high risk.
+- Useful target filtering is only a boolean boss-level `filter_add_damage` rule. uwu-logs has richer encounter-specific useful-target tables.
+- Absorbs remain intentionally separate from healing done, but the app does not yet expose a separate absorbs metric.
+- `/parse-stream` does not currently repeat the filename extension validation that `/parse` and `/parse-debug` perform.
+- `/api/upload` documents a 1 GB client limit but still lacks a hard web-route byte limit before forwarding.
+
+## Target Architecture
+
+Keep the public parser response shape stable unless tests justify a schema migration. Split testable responsibilities without rewriting the product surface:
+
+- `combat_log_events.py`: raw line tokenizer and event normalization helpers.
+- `parser_core.py`: encounter segmentation, attempt/session grouping, boss/difficulty/outcome policy, and aggregation orchestration.
+- `bosses.py`: canonical boss aliases, IDs, and useful-target policy.
+- `main.py`: upload receiving, temp-file handling, parser invocation, and SSE serialization.
+- Next.js upload route: streaming proxy, parser response validation, duplicate detection, and persistence adapter.
+
+Longer-term candidates:
+
+- `encounter_segments.py`: marker and heuristic segmenters, including mixed marker/no-marker fallback and boss-specific idle windows.
+- `metrics.py`: raw damage, useful damage, effective healing, overheal, overkill, absorbs, DPS/HPS.
+- `upload_result.py`: parser warning and skipped-line summary model shared by `/parse`, `/parse-stream`, and `/parse-debug`.
+
+## TDD Plan
+
+Add failing tests before production changes:
+
+1. Explicit marker segments with fewer than 10 events still produce an encounter.
+2. A heroic wipe followed by a normal kill in the same session remains `25H` then `25N`, not two `25H` rows.
+3. Malformed lines are counted and surfaced without crashing.
+4. Raw tokenizer and metric tests cover valid lines, bad timestamp separators, malformed CSV, shifted `SWING_DAMAGE` fields, and heal/damage formulas.
+5. Upload parser endpoints reject unsupported filenames consistently.
+
+Then refactor behind the tests:
+
+1. Extract line tokenizing and skipped-line accounting.
+2. Preserve current Skada-aligned event sets and existing field indexes.
+3. Relax the event floor only for explicit marker windows.
+4. Replace broad session promotion with evidence-first difficulty normalization.
+5. Add parser warnings for skipped/malformed lines without changing persisted database schema.
+6. Keep `totalDamage`, `dps`, `totalHealing`, and `hps` behavior stable unless a focused failing test proves a current value is wrong.
+
+## Risk Areas
+
+- Parser math affects leaderboards, milestones, weekly rankings, and player profiles.
+- Difficulty changes affect encounter fingerprints and duplicate detection.
+- Changing `totalDamage` semantics would alter historical leaderboard comparability; avoid without a dedicated migration plan.
+- Mixed marker/no-marker handling can accidentally double-count if marker and heuristic windows overlap.
+- Upload route changes can break long-running SSE streams if the parser response contract drifts.
+- Any schema change would require Prisma migration review and Railway production risk notes.
+
+## Assumptions
+
+- Skada-WoTLK "Damage Done" and "Useful Damage" are separate in-game modes; Pizza Logs currently stores one damage value and uses it for DPS leaderboards.
+- Until the database has separate raw/useful fields, Pizza Logs should keep current `totalDamage` leaderboard semantics stable and document the limitation.
+- Difficulty should come from direct encounter marker IDs or in-segment evidence first. Session promotion is allowed only when the rule cannot cross-contaminate a normal fallback attempt.
+- Synthetic fixtures are acceptable for edge cases that cannot be sourced from private user uploads.
+- Real combat logs must not be committed unless trimmed and anonymized.
+
+## Validation Baseline
+
+Baseline before logic edits:
+
+```powershell
+& 'C:\Users\neil_\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m pytest tests/ -v
+```
+
+Result: `123 passed`.
+
+## Implemented In This Refactor
+
+- Added `parser/combat_log_events.py` for raw line tokenizing and malformed-line classification.
+- Added `parser/combat_metrics.py` for Skada-aligned damage/healing field extraction and explicit encounter/session damage formulas.
+- `CombatLogParser._iter_lines` now counts malformed non-blank lines and returns an aggregate parser warning.
+- Explicit `ENCOUNTER_START` / `ENCOUNTER_END` windows are no longer discarded by the heuristic minimum-event floor.
+- Difficulty normalization no longer promotes non-Gunship `25N` pulls to `25H` solely because another pull in the same session was heroic.
+- Added focused tests for short marker windows, heroic-wipe-to-normal-kill fallback, tokenizer behavior, metric field extraction, malformed-line warnings, and `/parse-stream` file extension validation.
+- `/parse-stream` now rejects unsupported filename extensions before writing temp files, matching `/parse` and `/parse-debug`.

--- a/docs/parser-contract.md
+++ b/docs/parser-contract.md
@@ -44,7 +44,10 @@ inactivity window closes the encounter.
 
 ### Minimum event floor
 
-Segments with fewer than 10 events are discarded as noise (trash, pre-pull).
+Heuristic segments with fewer than 10 events are discarded as noise (trash,
+pre-pull). Explicit `ENCOUNTER_START` / `ENCOUNTER_END` marker windows are
+trusted even when short, so partial logs and very quick wipes can still produce
+an encounter.
 
 ---
 
@@ -112,10 +115,13 @@ If any of the following spell names appear in the segment AND difficulty is curr
 
 ### Step 3: Session normalization
 
-- Gunship Battle: always inherits session difficulty (no heroic-exclusive spells)
-- 25N encounter in a confirmed 25H session: promoted to 25H
-  (covers Sindragosa + BPC whose markers were removed in Step 2)
-- 10N encounters: never promoted (group-size detection is reliable for 10-player)
+- Gunship Battle: can inherit session heroic difficulty because Warmane provides
+  no reliable Gunship-only heroic marker.
+- Non-Gunship `25N` attempts are not promoted solely because another pull in the
+  same session was heroic. This prevents heroic wipes followed by a normal kill
+  from being bucketed under heroic.
+- Sindragosa and Blood Prince Council without direct heroic evidence remain
+  normal because their ambiguous Warmane spells also appear in 10N.
 
 ---
 
@@ -141,7 +147,8 @@ parts[10] = amount
 parts[11] = overkill
 parts[15] = absorbed
 ```
-Effective damage = `max(0, amount - overkill)`
+Stored encounter damage = `max(0, amount - overkill - absorbed)`.
+Full-session `sessionDamage` uses `amount + absorbed`.
 
 **SWING_DAMAGE** (no spell fields — indices shift by 3):
 ```
@@ -149,7 +156,8 @@ parts[7] = amount
 parts[8] = overkill
 parts[12] = absorbed
 ```
-Effective damage = `max(0, amount - overkill)`
+Stored encounter damage = `max(0, amount - overkill - absorbed)`.
+Full-session `sessionDamage` uses `amount + absorbed`.
 
 ### Add-wave filtering
 
@@ -267,7 +275,8 @@ A GUID is considered a player if it matches any of:
 2. **Gunship Battle**: Warmane always emits success=0 for Gunship; crew death override
    is required.
 3. **Difficulty undetectable cases**: Sindragosa, Blood Prince Council (heroic markers
-   removed due to Warmane 10N false positives); these rely on session promotion.
+   removed due to Warmane 10N false positives); absent direct evidence they stay
+   normal rather than inheriting heroic from another pull.
 4. **Absorbs not tracked**: PW:S and other absorb shields not yet implemented.
 5. **Post-death events**: Some servers log damage/heal events after player/boss death;
    not explicitly filtered (negligible impact on totals).
@@ -275,13 +284,16 @@ A GUID is considered a player if it matches any of:
 7. **Overkill not surfaced**: Tracked internally but not displayed separately in UI.
 8. **No ENCOUNTER_START on all Warmane bosses**: Not all Warmane bosses emit these;
    heuristic path is used as fallback throughout.
+9. **Malformed-line reporting is aggregate only**: uploads surface counts of malformed
+   lines as warnings, not every skipped line.
 
 ---
 
-## Values Expected to Match Skada Exactly
+## Values Expected to Match Skada Closely
 
 - Total healing (effective heal = gross - overheal, no spell exclusions)
-- Total damage (same event set as Skada, same overkill subtraction)
+- Stored encounter damage uses the Skada damage event set, then excludes overkill
+  and absorbed shield damage for Pizza Logs leaderboard stability.
 - DPS (same encounter duration rule: boss death timestamp for kills)
 - HPS (same rule)
 - Pet attribution (owner gets credit)

--- a/parser/combat_log_events.py
+++ b/parser/combat_log_events.py
@@ -1,0 +1,67 @@
+"""Combat-log line tokenizing helpers.
+
+This module is intentionally small: it knows how to split one raw
+WoWCombatLog.txt line into timestamp, CSV parts, and seconds since midnight.
+Encounter policy stays in parser_core.py.
+"""
+
+from __future__ import annotations
+
+import csv as _csv
+import io
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+TS_RE = re.compile(
+    r"^(\d{1,2})/(\d{1,2})\s+(\d{2}):(\d{2}):(\d{2})\.(\d{3})"
+)
+
+
+@dataclass(frozen=True)
+class CombatLogLine:
+    ts_str: str
+    parts: list[str]
+    ts: float
+
+
+@dataclass(frozen=True)
+class ParsedLineResult:
+    line: Optional[CombatLogLine]
+    skip_reason: Optional[str] = None
+
+
+def csv_split(s: str) -> list[str]:
+    reader = _csv.reader(io.StringIO(s), skipinitialspace=True)
+    return [x.strip() for x in next(reader)]
+
+
+def parse_ts(ts_str: str) -> float:
+    m = TS_RE.match(ts_str)
+    if not m:
+        return 0.0
+    _, _, hh, mm, ss, ms = m.groups()
+    return int(hh) * 3600 + int(mm) * 60 + int(ss) + int(ms) / 1000
+
+
+def parse_combat_log_line(raw_line: str) -> ParsedLineResult:
+    line = raw_line.strip()
+    if not line:
+        return ParsedLineResult(None, "blank")
+
+    space_idx = line.find("  ")
+    if space_idx == -1:
+        return ParsedLineResult(None, "missing_timestamp_separator")
+
+    ts_str = line[:space_idx].strip()
+    rest = line[space_idx + 2:]
+    try:
+        parts = csv_split(rest)
+    except Exception:
+        return ParsedLineResult(None, "malformed_csv")
+
+    if len(parts) < 2:
+        return ParsedLineResult(None, "too_few_fields")
+
+    return ParsedLineResult(CombatLogLine(ts_str=ts_str, parts=parts, ts=parse_ts(ts_str)))

--- a/parser/combat_metrics.py
+++ b/parser/combat_metrics.py
@@ -1,0 +1,95 @@
+"""Skada-aligned combat event metric extraction helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class DamageFields:
+    amount: float
+    overkill: float
+    absorbed: float
+    school: int
+    is_crit: bool
+    spell_name: str
+
+
+@dataclass(frozen=True)
+class HealFields:
+    gross: float
+    overheal: float
+    absorbed: float
+    effective: float
+    school: int
+    is_crit: bool
+    spell_name: str
+
+
+def extract_damage_fields(parts: list[str]) -> Optional[DamageFields]:
+    event = parts[0] if parts else ""
+    if event == "SWING_DAMAGE":
+        if len(parts) < 14:
+            return None
+        return DamageFields(
+            amount=_safe_float(parts[7]),
+            overkill=_safe_float(parts[8]),
+            absorbed=_safe_float(parts[12]) if len(parts) > 12 else 0.0,
+            school=_safe_int(parts[9]) or 1,
+            is_crit=parts[13] == "1",
+            spell_name="Auto Attack",
+        )
+
+    if len(parts) < 15:
+        return None
+    return DamageFields(
+        amount=_safe_float(parts[10]),
+        overkill=_safe_float(parts[11]),
+        absorbed=_safe_float(parts[15]) if len(parts) > 15 else 0.0,
+        school=_safe_int(parts[9]) or 1,
+        is_crit=len(parts) > 17 and parts[17] == "1",
+        spell_name=parts[8].strip('"').strip(),
+    )
+
+
+def extract_heal_fields(parts: list[str]) -> Optional[HealFields]:
+    if len(parts) < 11:
+        return None
+    gross = _safe_float(parts[10])
+    overheal = _safe_float(parts[11]) if len(parts) > 11 else 0.0
+    absorbed = _safe_float(parts[12]) if len(parts) > 12 else 0.0
+    return HealFields(
+        gross=gross,
+        overheal=overheal,
+        absorbed=absorbed,
+        effective=max(0.0, gross - overheal),
+        school=_safe_int(parts[9]) or 2,
+        is_crit=len(parts) > 13 and parts[13] == "1",
+        spell_name=parts[8].strip('"').strip(),
+    )
+
+
+def encounter_damage_amount(fields: DamageFields) -> float:
+    """Damage stored for encounter DPS: excludes overkill and absorbed shield damage."""
+    return max(0.0, fields.amount - fields.overkill - fields.absorbed)
+
+
+def session_damage_amount(fields: DamageFields) -> float:
+    """Full-session output convention: count unabsorbed plus absorbed output."""
+    return max(0.0, fields.amount + fields.absorbed)
+
+
+def _safe_int(s: str) -> int:
+    try:
+        return int(s.strip(), 0)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _safe_float(s: str) -> float:
+    try:
+        v = float(s.strip())
+        return max(0.0, v)
+    except (ValueError, TypeError):
+        return 0.0

--- a/parser/main.py
+++ b/parser/main.py
@@ -415,6 +415,9 @@ async def parse_log_stream(
     FastAPI closes UploadFile when the endpoint function returns, so the async
     generator cannot read from `file` after that point.
     """
+    if file.filename and not file.filename.lower().endswith((".txt", ".log")):
+        raise HTTPException(400, "Only .txt and .log files are supported")
+
     # ── Write file to disk NOW (before returning StreamingResponse) ──
     sha256     = hashlib.sha256()
     first_chunk= b""

--- a/parser/parser_core.py
+++ b/parser/parser_core.py
@@ -10,15 +10,21 @@ Supports:
 
 from __future__ import annotations
 
-import csv as _csv
 import hashlib
+import csv as _csv
 import re
-import io
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Generator, Optional, TextIO
 
 from bosses import BossDef, lookup_boss, lookup_boss_by_id, ALL_BOSS_NAMES
+from combat_log_events import parse_combat_log_line
+from combat_metrics import (
+    encounter_damage_amount,
+    extract_damage_fields,
+    extract_heal_fields,
+    session_damage_amount,
+)
 
 # ── Constants ─────────────────────────────────────────────────────
 
@@ -37,8 +43,8 @@ HEROIC_SPELL_MARKERS: frozenset[str] = frozenset({
     # NOTE: "backlash" (Sindragosa) and "empowered shock vortex" / "empowered shadow lance" /
     # "empowered blood" (Blood Prince Council) are intentionally EXCLUDED here.
     # On Warmane these spells also appear in 10N, so they cannot be used as heroic-exclusive
-    # markers.  Sindragosa and BPC in a 25H session instead inherit the session's heroic
-    # difficulty via _normalize_session_difficulty (25N → 25H promotion).
+    # markers.  Sindragosa and BPC without direct heroic evidence stay normal rather
+    # than inheriting heroic state from another pull in the same session.
 })
 
 # Gunship Battle: Warmane emits ENCOUNTER_END success=0 even on a genuine kill
@@ -325,6 +331,8 @@ class CombatLogParser:
         self.raw_count    = 0
         self.warnings: list[str] = []
         self.session_damage: dict[int, float] = {}
+        self.skipped_line_count = 0
+        self.skipped_line_reasons: dict[str, int] = {}
         # Cache boss name set once — this is hit millions of times during segmentation
         self._boss_name_set: set[str] = ALL_BOSS_NAMES
 
@@ -350,6 +358,10 @@ class CombatLogParser:
                 encounters.append(enc)
         self._assign_session_indices(encounters)
         self._normalize_session_difficulty(encounters)
+        if self.skipped_line_count:
+            self.warnings.append(
+                f"Skipped {self.skipped_line_count} malformed combat-log lines."
+            )
         return encounters
 
     @staticmethod
@@ -361,12 +373,9 @@ class CombatLogParser:
         1. Gunship Battle: Warmane emits difficultyID=4 (25N) even on heroic kills
            because the boss has no heroic-exclusive spells.  Always inherit from session.
 
-        2. 25N encounters in a confirmed 25H session: some bosses (Sindragosa, Blood Prince
-           Council) have spells that look heroic-exclusive but also appear in 10N on Warmane,
-           so their markers were removed from HEROIC_SPELL_MARKERS.  In a 25H session (where
-           other bosses confirmed heroic via reliable markers like Marrowgar "Bone Slice" or
-           Saurfang "Rune of Blood") any remaining 25N encounter is promoted to 25H.
-           10N encounters are never promoted — group-size detection is reliable.
+        Do not broadly promote normal-looking attempts to heroic based only on another
+        heroic encounter in the same session. Warmane raids can wipe on heroic and then
+        kill on normal; cross-attempt promotion would bucket that normal kill under heroic.
         """
         by_session: dict[int, list["ParsedEncounter"]] = {}
         for enc in encounters:
@@ -385,11 +394,6 @@ class CombatLogParser:
                 if "gunship" in bn:
                     # Gunship: always inherit session difficulty
                     enc.difficulty = heroic_diff
-                elif heroic_diff == "25H" and enc.difficulty == "25N":
-                    # 25N encounter in a confirmed 25H session → promote to 25H.
-                    # 10N encounters are intentionally left alone (10N and 10H can
-                    # coexist across sessions; group-size detection is reliable for 10).
-                    enc.difficulty = "25H"
 
     @staticmethod
     def _assign_session_indices(
@@ -431,23 +435,16 @@ class CombatLogParser:
             self.raw_count += 1
             if progress_cb and self.raw_count % _REPORT_EVERY == 0:
                 progress_cb(self.raw_count, total_lines)
-            line = raw_line.strip()
-            if not line:
+            result = parse_combat_log_line(raw_line)
+            if result.line is None:
+                reason = result.skip_reason or "unknown"
+                if reason != "blank":
+                    self.skipped_line_count += 1
+                    self.skipped_line_reasons[reason] = (
+                        self.skipped_line_reasons.get(reason, 0) + 1
+                    )
                 continue
-            # Split timestamp from the rest
-            space_idx = line.find("  ")
-            if space_idx == -1:
-                continue
-            ts_str = line[:space_idx].strip()
-            rest   = line[space_idx + 2:]
-            try:
-                parts = csv_split(rest)
-            except Exception:
-                continue
-            if len(parts) < 2:
-                continue
-            ts = parse_ts(ts_str)
-            yield ts_str, parts, ts
+            yield result.line.ts_str, result.line.parts, result.line.ts
 
     # ── Internal: segmentation ───────────────────────────────────
 
@@ -544,20 +541,10 @@ class CombatLogParser:
                         except (ValueError, TypeError):
                             pass
                 if (is_player or is_pet) and not _is_player(dst_guid):
-                    try:
-                        if event == "SWING_DAMAGE" and len(parts) >= 9:
-                            absorbed = _safe_float(parts[12]) if len(parts) > 12 else 0.0
-                            # Skada counts amount+absorbed without subtracting overkill
-                            eff = max(0.0, float(parts[7]) + absorbed)
-                        elif len(parts) >= 12:
-                            absorbed = _safe_float(parts[15]) if len(parts) > 15 else 0.0
-                            # Skada counts amount+absorbed without subtracting overkill
-                            eff = max(0.0, float(parts[10]) + absorbed)
-                        else:
-                            eff = 0.0
+                    fields = extract_damage_fields(parts)
+                    if fields:
+                        eff = session_damage_amount(fields)
                         _full_dmg[_full_session_idx] = _full_dmg.get(_full_session_idx, 0.0) + eff
-                    except (ValueError, IndexError):
-                        pass
 
             # ── SPELL_SUMMON: build pet→owner map (global, outside segments) ──
             if event == "SPELL_SUMMON" and len(parts) >= 5:
@@ -601,8 +588,7 @@ class CombatLogParser:
                 has_encounter_events = True
                 if current_segment:
                     current_segment.append((ts_str, parts, ts))
-                    if len(current_segment) >= MIN_ENCOUNTER_EVENTS:
-                        segments.append(current_segment)
+                    segments.append(current_segment)
                 current_segment = []
                 in_encounter = False
                 continue
@@ -646,7 +632,7 @@ class CombatLogParser:
 
         # Flush trailing segment
         if has_encounter_events:
-            if current_segment and len(current_segment) >= MIN_ENCOUNTER_EVENTS:
+            if current_segment:
                 segments.append(current_segment)
         else:
             if heuristic_segment and len(heuristic_segment) >= MIN_ENCOUNTER_EVENTS:
@@ -836,16 +822,17 @@ class CombatLogParser:
             # Fields: event,srcGUID,srcName,srcFlags,dstGUID,dstName,dstFlags,
             #   amount,overkill,school,resisted,blocked,absorbed,critical
             if event == "SWING_DAMAGE":
-                if len(parts) < 14:
+                fields = extract_damage_fields(parts)
+                if not fields:
                     continue
                 src_guid, src_name = parts[1], parts[2].strip('"').strip()
                 dst_guid, dst_name = parts[4], parts[5].strip('"').strip()
-                amount   = _safe_float(parts[7])
-                overkill = _safe_float(parts[8])
-                absorbed = _safe_float(parts[12]) if len(parts) > 12 else 0.0
-                school   = _safe_int(parts[9]) or 1
-                is_crit  = parts[13] == "1"
-                spell_name = "Auto Attack"
+                amount = fields.amount
+                overkill = fields.overkill
+                absorbed = fields.absorbed
+                school = fields.school
+                is_crit = fields.is_crit
+                spell_name = fields.spell_name
             elif is_heal:
                 # SPELL_HEAL / SPELL_PERIODIC_HEAL field layout (Warmane WotLK 3.3.5a):
                 #   event,srcGUID,srcName,srcFlags,dstGUID,dstName,dstFlags,
@@ -857,20 +844,19 @@ class CombatLogParser:
                 # parts[12] = absorbed — portion absorbed by absorb shields
                 # parts[13] = critical — "1" or nil
                 #
-                # Effective heal (HP actually restored) = amount - overheal - absorbed
-                # ≈ parts[10] - parts[11]  (parts[12] is 0 for player→player heals in practice)
-                if len(parts) < 11:
+                # Effective heal (HP actually restored) = gross - overheal.
+                # Absorbs are tracked separately by Skada, not added to healing done.
+                fields = extract_heal_fields(parts)
+                if not fields:
                     continue
                 src_guid, src_name = parts[1], parts[2].strip('"').strip()
                 dst_guid, dst_name = parts[4], parts[5].strip('"').strip()
-                spell_name = parts[8].strip('"').strip()
-                school     = _safe_int(parts[9]) or 2
-                gross      = _safe_float(parts[10])
-                overheal   = _safe_float(parts[11]) if len(parts) > 11 else 0.0
-                amount     = max(0.0, gross - overheal)   # effective HP restored
-                overkill   = 0.0
-                absorbed   = 0.0
-                is_crit    = len(parts) > 13 and parts[13] == "1"
+                spell_name = fields.spell_name
+                school = fields.school
+                amount = fields.effective
+                overkill = 0.0
+                absorbed = 0.0
+                is_crit = fields.is_crit
             else:
                 # All remaining events must be in DMG_EVENTS — defence-in-depth
                 # guard against any unrecognised events slipping through.
@@ -879,16 +865,17 @@ class CombatLogParser:
                 # SPELL_DAMAGE / SPELL_PERIODIC_DAMAGE / RANGE_DAMAGE etc.
                 # Fields: event,srcGUID,srcName,srcFlags,dstGUID,dstName,dstFlags,
                 #   spellID,spellName,spellSchool,amount,overkill,school,resisted,blocked,absorbed,??,critical
-                if len(parts) < 15:
+                fields = extract_damage_fields(parts)
+                if not fields:
                     continue
                 src_guid, src_name = parts[1], parts[2].strip('"').strip()
                 dst_guid, dst_name = parts[4], parts[5].strip('"').strip()
-                spell_name = parts[8].strip('"').strip()
-                school     = _safe_int(parts[9]) or 1
-                amount     = _safe_float(parts[10])
-                overkill   = _safe_float(parts[11])
-                absorbed   = _safe_float(parts[15]) if len(parts) > 15 else 0.0
-                is_crit    = len(parts) > 17 and parts[17] == "1"
+                spell_name = fields.spell_name
+                school = fields.school
+                amount = fields.amount
+                overkill = fields.overkill
+                absorbed = fields.absorbed
+                is_crit = fields.is_crit
 
             if amount <= 0:
                 continue
@@ -934,7 +921,11 @@ class CombatLogParser:
             # Saurfang blood barrier) — never reaches HP. UWU excludes both.
             # For heals, `amount` is already the effective value (gross - overheal),
             # computed above from parts[10] - parts[11].
-            eff_amount = max(0.0, amount - overkill - absorbed) if not is_heal else amount
+            eff_amount = (
+                amount
+                if is_heal
+                else encounter_damage_amount(fields)
+            )
 
             a = _get_actor(actors, src_name, src_guid)
             ss = a.spells.setdefault(spell_name, SpellStats(school=school))

--- a/parser/tests/test_combat_log_events.py
+++ b/parser/tests/test_combat_log_events.py
@@ -1,0 +1,36 @@
+"""Unit tests for combat-log line tokenizing and skipped-line classification."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from combat_log_events import parse_combat_log_line
+
+
+def test_parse_combat_log_line_returns_timestamp_parts_and_seconds():
+    result = parse_combat_log_line(
+        '4/19 13:00:01.250  SPELL_DAMAGE,0x0600000000000001,"Phyre",0x512,'
+        '0xF130000000000001,"Lord Marrowgar",0xa48,133,"Fireball",4,1234,0,4,0,0,0,0,0'
+    )
+
+    assert result.line is not None
+    assert result.skip_reason is None
+    assert result.line.ts_str == "4/19 13:00:01.250"
+    assert result.line.parts[0] == "SPELL_DAMAGE"
+    assert result.line.parts[2] == "Phyre"
+    assert result.line.ts == 46801.25
+
+
+def test_parse_combat_log_line_classifies_missing_timestamp_separator():
+    result = parse_combat_log_line("4/19 13:00:01.250 SPELL_DAMAGE,missing,double,space")
+
+    assert result.line is None
+    assert result.skip_reason == "missing_timestamp_separator"
+
+
+def test_parse_combat_log_line_classifies_too_few_fields():
+    result = parse_combat_log_line("4/19 13:00:01.250  SPELL_DAMAGE")
+
+    assert result.line is None
+    assert result.skip_reason == "too_few_fields"

--- a/parser/tests/test_combat_metrics.py
+++ b/parser/tests/test_combat_metrics.py
@@ -1,0 +1,74 @@
+"""Unit tests for Skada-aligned combat event metric extraction."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from combat_metrics import (
+    encounter_damage_amount,
+    extract_damage_fields,
+    extract_heal_fields,
+    session_damage_amount,
+)
+
+
+def test_extract_spell_damage_fields_and_formulas():
+    parts = [
+        "SPELL_DAMAGE",
+        "0x0600000000000001", "Phyre", "0x512",
+        "0xF130000000000001", "Lord Marrowgar", "0xa48",
+        "133", "Fireball", "4",
+        "1000", "250", "4", "0", "0", "100", "0", "1",
+    ]
+
+    fields = extract_damage_fields(parts)
+
+    assert fields is not None
+    assert fields.amount == 1000
+    assert fields.overkill == 250
+    assert fields.absorbed == 100
+    assert fields.school == 4
+    assert fields.is_crit is True
+    assert fields.spell_name == "Fireball"
+    assert encounter_damage_amount(fields) == 650
+    assert session_damage_amount(fields) == 1100
+
+
+def test_extract_swing_damage_uses_shifted_wotlk_indexes():
+    parts = [
+        "SWING_DAMAGE",
+        "0x0600000000000001", "Phyre", "0x512",
+        "0xF130000000000001", "Lord Marrowgar", "0xa48",
+        "1000", "250", "1", "0", "0", "100", "1",
+    ]
+
+    fields = extract_damage_fields(parts)
+
+    assert fields is not None
+    assert fields.amount == 1000
+    assert fields.overkill == 250
+    assert fields.absorbed == 100
+    assert fields.school == 1
+    assert fields.is_crit is True
+    assert fields.spell_name == "Auto Attack"
+
+
+def test_extract_heal_fields_uses_effective_healing():
+    parts = [
+        "SPELL_HEAL",
+        "0x0600000000000001", "Healz", "0x512",
+        "0x0600000000000002", "Tank", "0x512",
+        "48782", "Holy Light", "2",
+        "5000", "1250", "0", "1",
+    ]
+
+    fields = extract_heal_fields(parts)
+
+    assert fields is not None
+    assert fields.gross == 5000
+    assert fields.overheal == 1250
+    assert fields.effective == 3750
+    assert fields.school == 2
+    assert fields.is_crit is True
+    assert fields.spell_name == "Holy Light"

--- a/parser/tests/test_parser_core.py
+++ b/parser/tests/test_parser_core.py
@@ -6,6 +6,7 @@ Run from the parser/ directory:
 """
 import sys
 import os
+import io
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import pytest
@@ -127,6 +128,10 @@ def make_gunship_segment(
     ]
 
 
+def _log_line(ts: str, parts: list[str]) -> str:
+    return f"{ts}  {','.join(parts)}\n"
+
+
 # ── DMG_EVENTS membership — sourced from Skada Damage.lua RegisterForCL ───────
 #
 # Skada registers: SPELL_DAMAGE, SWING_DAMAGE, RANGE_DAMAGE, SPELL_PERIODIC_DAMAGE,
@@ -156,6 +161,42 @@ def test_core_dmg_events_present():
 
 
 # ── Difficulty decoding ────────────────────────────────────────────────────────
+
+def test_short_explicit_marker_encounter_is_parsed():
+    """ENCOUNTER_START/END is authoritative even when a partial log has few events."""
+    log = "".join([
+        _log_line("4/19 13:00:00.000", [ENCOUNTER_START, "36612", '"Lord Marrowgar"', "4", "25"]),
+        _log_line(
+            "4/19 13:00:01.000",
+            _spell_damage_parts(PLAYER_GUID, "Phyre", NPC_GUID, "Lord Marrowgar", 1234),
+        ),
+        _log_line("4/19 13:00:02.000", _unit_died_parts("Lord Marrowgar")),
+        _log_line("4/19 13:00:02.100", [ENCOUNTER_END, "36612", '"Lord Marrowgar"', "4", "25", "1"]),
+    ])
+
+    encounters = CombatLogParser().parse_file(io.StringIO(log))
+
+    assert len(encounters) == 1
+    assert encounters[0].boss_name == "Lord Marrowgar"
+    assert encounters[0].outcome == "KILL"
+    assert encounters[0].total_damage == 1234
+
+
+def test_malformed_lines_are_counted_and_warned():
+    """Bad input lines should be counted and reported without crashing parsing."""
+    parser = CombatLogParser()
+    encounters = parser.parse_file(io.StringIO("\n".join([
+        "this is not a combat log line",
+        "4/19 13:00:01.000  SPELL_DAMAGE",
+        "",
+    ])))
+
+    assert encounters == []
+    assert parser.skipped_line_count == 2
+    assert parser.skipped_line_reasons["missing_timestamp_separator"] == 1
+    assert parser.skipped_line_reasons["too_few_fields"] == 1
+    assert "Skipped 2 malformed combat-log lines." in parser.warnings
+
 
 def test_decode_difficulty_25h():
     assert _decode_difficulty(6, 25) == "25H"
@@ -348,16 +389,8 @@ def test_gunship_difficulty_unchanged_in_all_normal_session():
     assert gunship.difficulty == "25N"
 
 
-def test_25n_in_25h_session_promoted_by_normalization():
-    """Any 25N encounter inside a confirmed 25H session must be promoted to 25H.
-
-    In ICC (and all WotLK raids) 25N and 25H share a single lockout — you cannot
-    mix difficulties within a session.  So if Marrowgar is detected as 25H (via
-    'Bone Slice' marker), every other 25N encounter in the same session is actually
-    heroic and should be promoted.  This handles bosses whose heroic markers were
-    removed because they also fire in 10N on Warmane (Sindragosa, BPC).
-    10N encounters are intentionally left alone.
-    """
+def test_25n_non_gunship_in_25h_session_is_not_promoted_without_evidence():
+    """Normal-looking non-Gunship attempts must not inherit heroic session state."""
     encounters = [
         make_encounter("Lord Marrowgar", difficulty="25H", session_index=0),
         make_encounter("Lady Deathwhisper", difficulty="25N", session_index=0),
@@ -365,9 +398,24 @@ def test_25n_in_25h_session_promoted_by_normalization():
     ]
     CombatLogParser._normalize_session_difficulty(encounters)
     dw = next(e for e in encounters if "deathwhisper" in e.boss_name.lower())
-    assert dw.difficulty == "25H", (
-        f"Lady Deathwhisper 25N in a 25H session must be promoted to '25H', got '{dw.difficulty}'"
+    gunship = next(e for e in encounters if "gunship" in e.boss_name.lower())
+    assert dw.difficulty == "25N", (
+        f"Lady Deathwhisper without direct heroic evidence must stay '25N', got '{dw.difficulty}'"
     )
+    assert gunship.difficulty == "25H"
+
+
+def test_heroic_wipe_then_normal_kill_keeps_normal_difficulty():
+    """A later normal kill after heroic wipes must not inherit heroic session state."""
+    encounters = [
+        make_encounter("Lord Marrowgar", difficulty="25H", session_index=0, outcome="WIPE"),
+        make_encounter("Lord Marrowgar", difficulty="25N", session_index=0, outcome="KILL"),
+    ]
+
+    CombatLogParser._normalize_session_difficulty(encounters)
+
+    assert encounters[0].difficulty == "25H"
+    assert encounters[1].difficulty == "25N"
 
 
 def test_gunship_difficulty_not_cross_contaminated_across_sessions():
@@ -1931,21 +1979,17 @@ def test_bpc_10n_empowered_shock_vortex_does_not_upgrade_to_heroic():
     )
 
 
-def test_normalize_session_difficulty_upgrades_25n_sindragosa_to_25h():
+def test_normalize_session_difficulty_keeps_25n_sindragosa_without_direct_evidence():
     """
-    When a session has other 25H encounters (detected via reliable markers like
-    'Bone Slice' on Marrowgar), any 25N encounter in the same session must be
-    upgraded to 25H by _normalize_session_difficulty.
-
-    This handles Sindragosa and BPC in a 25H session where their own heroic
-    spell markers have been removed (they fire in 10N too on Warmane).
+    Sindragosa has Warmane marker ambiguity, so absent direct proof is reported
+    as normal instead of guessing heroic from another encounter in the session.
     """
     marrowgar_25h = make_encounter("Lord Marrowgar", difficulty="25H", session_index=0)
     sindragosa_25n = make_encounter("Sindragosa", difficulty="25N", session_index=0)
     encounters = [marrowgar_25h, sindragosa_25n]
     CombatLogParser._normalize_session_difficulty(encounters)
-    assert sindragosa_25n.difficulty == "25H", (
-        f"Sindragosa 25N in a 25H session must be upgraded to '25H', "
+    assert sindragosa_25n.difficulty == "25N", (
+        f"Sindragosa without direct heroic evidence must stay '25N', "
         f"got '{sindragosa_25n.difficulty}'"
     )
 

--- a/parser/tests/test_parser_service.py
+++ b/parser/tests/test_parser_service.py
@@ -1,0 +1,26 @@
+"""FastAPI parser-service upload contract tests."""
+
+import io
+import os
+import sys
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from main import parse_log_stream
+
+
+@pytest.mark.anyio
+async def test_parse_stream_rejects_unsupported_filename_extension():
+    upload = UploadFile(
+        filename="not-a-log.exe",
+        file=io.BytesIO(b"not a combat log"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await parse_log_stream(file=upload, year_hint=0)
+
+    assert exc_info.value.status_code == 400
+    assert "Only .txt and .log files are supported" in exc_info.value.detail


### PR DESCRIPTION
## Summary

- Add a parser audit note covering current upload flow, Skada-WoTLK and uwu-logs reference findings, target architecture, risks, assumptions, and the test plan.
- Split raw combat-log tokenizing and combat metric extraction into focused Python modules with unit tests.
- Harden parser behavior for malformed lines, short explicit marker encounters, stream upload filename validation, and heroic-to-normal fallback attempts.
- Update README, parser contract docs, vault architecture/security/current-focus notes, decision log, and known issues.

## Validation

- `python -m pytest tests/ -v` from `parser/`: `133 passed, 1 warning`
- TypeScript `tsc --noEmit` via bundled Node: passed
- ESLint via bundled Node: passed
- Next production build via bundled Node: passed
- `git diff --check`: passed
- Staged secret scan: no matches

## Review focus

@codex review please focus on parser correctness and Skada alignment, fixture coverage, combat-log edge cases, upload response contract, difficulty bucketing after heroic-to-normal fallback, accidental secret exposure, and docs drift.