### PR TITLE
[codex] Retarget local launchers to Projects checkout

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -18,11 +18,11 @@
 - Local Git executable fallback: `C:\Program Files\Git\cmd\git.exe`
 - GitHub CLI executable: `C:\Program Files\GitHub CLI\gh.exe`
 - Parser correctness remains the highest-risk area.
-- Local desktop launchers:
-  - `C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd`
-  - `C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd`
-- The desktop launchers now point to `C:\Projects\PizzaLogs`; the old OneDrive checkout can stay as a temporary fallback.
-- The repeating `PizzaLogsLocalTestServer` scheduled task is disabled; use the desktop launchers instead.
+- Local repo-root launchers:
+  - `C:\Projects\PizzaLogs\Start Pizza Logs Local.cmd`
+  - `C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd`
+- The old Desktop launcher copies were moved into the repo root; the old OneDrive checkout can stay as a temporary fallback.
+- The repeating `PizzaLogsLocalTestServer` scheduled task is disabled; use the repo-root launchers instead.
 
 ## Current Implementation Snapshot
 
@@ -77,7 +77,7 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 - Copied local-only `.env.local` and `.env.sync-agent` from the OneDrive checkout into `C:\Projects\PizzaLogs`.
 - Installed web dependencies and generated Prisma Client in the local checkout.
 - Created the parser virtualenv with bundled Python 3.12 because system Python 3.14 could not install pinned `pydantic-core` without MSVC build tools.
-- Retargeted both desktop launcher files and repo launcher templates from the OneDrive checkout to `C:\Projects\PizzaLogs`.
+- Moved the Start/Stop launcher files from the Desktop into `C:\Projects\PizzaLogs` and made them resolve the repo path from their own location.
 - Verified the local web server returned 200 at `http://127.0.0.1:3001/` and parser health returned 200 at `http://127.0.0.1:8000/health`.
 - PostgreSQL service `postgresql-x64-16` was stopped and could not be started from the non-admin Codex process; run the Start launcher as administrator if DB-backed routes return 500 locally.
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -23,6 +23,7 @@
   - `C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd`
 - The old Desktop launcher copies were moved into the repo root; the old OneDrive checkout can stay as a temporary fallback.
 - The repeating `PizzaLogsLocalTestServer` scheduled task is disabled; use the repo-root launchers instead.
+- Imported local Codex discussion history now lives under `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/`.
 
 ## Current Implementation Snapshot
 
@@ -80,6 +81,13 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 - Moved the Start/Stop launcher files from the Desktop into `C:\Projects\PizzaLogs` and made them resolve the repo path from their own location.
 - Verified the local web server returned 200 at `http://127.0.0.1:3001/` and parser health returned 200 at `http://127.0.0.1:8000/health`.
 - PostgreSQL service `postgresql-x64-16` was stopped and could not be started from the non-admin Codex process; run the Start launcher as administrator if DB-backed routes return 500 locally.
+
+## Chat History Import This Session
+
+- Imported 17 local Codex chats from `C:\Users\neil_\.codex\sessions` into the committed vault.
+- Index file: `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/Imported Codex Chats Index.md`.
+- Imported notes keep user messages and assistant final replies, while omitting raw JSONL, tool payloads, encrypted reasoning payloads, and `.env*` contents.
+- Secret-like values were redacted during import, and the imported vault notes were checked with `git grep --untracked` for obvious database URLs, tokens, and private-key patterns.
 
 ## Remaining Risks
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -90,4 +90,4 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 
 ## Exact Next Step
 
-Open or update the PR from `codex-dev` into `main` for the local checkout migration. Do not merge or push `main` directly.
+Review draft PR #11 from `codex-dev` into `main` for the local checkout migration. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -13,6 +13,7 @@
 - Pizza Logs is Codex-first: work happens on `codex-dev`, then PRs go into `main`.
 - Railway production deploys from `main` after Neil merges a PR.
 - Live app: https://pizza-logs-production.up.railway.app
+- Local working checkout for Neil's laptop: `C:\Projects\PizzaLogs`
 - Local app target for Neil's laptop: http://127.0.0.1:3001
 - Local Git executable fallback: `C:\Program Files\Git\cmd\git.exe`
 - GitHub CLI executable: `C:\Program Files\GitHub CLI\gh.exe`
@@ -20,6 +21,7 @@
 - Local desktop launchers:
   - `C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd`
   - `C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd`
+- The desktop launchers now point to `C:\Projects\PizzaLogs`; the old OneDrive checkout can stay as a temporary fallback.
 - The repeating `PizzaLogsLocalTestServer` scheduled task is disabled; use the desktop launchers instead.
 
 ## Current Implementation Snapshot
@@ -69,6 +71,16 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 | Next production build via bundled Node | Passed |
 | `git diff --check` | Passed |
 
+## Local Checkout Migration This Session
+
+- Set up and validated the GitHub-backed checkout at `C:\Projects\PizzaLogs`.
+- Copied local-only `.env.local` and `.env.sync-agent` from the OneDrive checkout into `C:\Projects\PizzaLogs`.
+- Installed web dependencies and generated Prisma Client in the local checkout.
+- Created the parser virtualenv with bundled Python 3.12 because system Python 3.14 could not install pinned `pydantic-core` without MSVC build tools.
+- Retargeted both desktop launcher files and repo launcher templates from the OneDrive checkout to `C:\Projects\PizzaLogs`.
+- Verified the local web server returned 200 at `http://127.0.0.1:3001/` and parser health returned 200 at `http://127.0.0.1:8000/health`.
+- PostgreSQL service `postgresql-x64-16` was stopped and could not be started from the non-admin Codex process; run the Start launcher as administrator if DB-backed routes return 500 locally.
+
 ## Remaining Risks
 
 - Absorbs are still not implemented as healing; Skada treats them separately.
@@ -78,4 +90,4 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 
 ## Exact Next Step
 
-Push the parser refactor commit to `origin/codex-dev`, then open or update the PR into `main` for review. Do not merge or push `main` directly.
+Open or update the PR from `codex-dev` into `main` for the local checkout migration. Do not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -25,7 +25,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Validation passed: full parser pytest suite, TypeScript type-check, ESLint, Next production build, and `git diff --check`.
 - Set up and validated `C:\Projects\PizzaLogs` as the local working checkout.
 - Copied local env files into the local checkout, installed dependencies, generated Prisma Client, and created a parser Python 3.12 virtualenv.
-- Retargeted the desktop Start/Stop launchers and `scripts/desktop/*.cmd` templates to `C:\Projects\PizzaLogs`.
+- Moved the Start/Stop launchers into `C:\Projects\PizzaLogs` and made them path-relative to the repo root.
 - Verified `http://127.0.0.1:3001/` and `http://127.0.0.1:8000/health` from the new checkout.
 
 ## Next Actions
@@ -42,7 +42,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Heroic-to-normal regression | DONE | Later normal kills stay normal without direct heroic evidence |
 | Documentation update | DONE | README, parser contract, vault parser docs, security, decision log, known issues |
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
-| Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers retargeted |
+| Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers live in repo root |
 | Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
 | PR update | DONE | Draft PR #11 opened from `codex-dev` into `main` |
 
@@ -55,7 +55,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.
 - Add anonymized larger upload fixtures if Neil can provide safe samples.
 - If the laptop port changes from `3001`, add matching local roster/gear userscript variants or update the local constants.
-- If the Desktop launcher copies drift, update `scripts/desktop/*.cmd` and copy them back to `C:\Users\neil_\OneDrive\Desktop`.
+- If the local launchers need edits, update `C:\Projects\PizzaLogs\Start Pizza Logs Local.cmd` and `C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd`.
 - If DB-backed local routes return 500, start PostgreSQL service `postgresql-x64-16` from an elevated shell or by running the Start launcher as administrator.
 
 ## Reference

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -27,6 +27,9 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Copied local env files into the local checkout, installed dependencies, generated Prisma Client, and created a parser Python 3.12 virtualenv.
 - Moved the Start/Stop launchers into `C:\Projects\PizzaLogs` and made them path-relative to the repo root.
 - Verified `http://127.0.0.1:3001/` and `http://127.0.0.1:8000/health` from the new checkout.
+- Imported 17 local Codex chats into `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/` so the new `C:\Projects\PizzaLogs` checkout carries the prior discussion history.
+- Kept the import as readable vault digests, not raw JSONL; tool logs, encrypted reasoning payloads, and `.env*` contents were omitted.
+- Ran an untracked secret-pattern scan against the imported notes after redaction.
 
 ## Next Actions
 
@@ -43,6 +46,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Documentation update | DONE | README, parser contract, vault parser docs, security, decision log, known issues |
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
 | Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers live in repo root |
+| Codex chat import | DONE | 17 readable vault digests under `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/` |
 | Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
 | PR update | DONE | Draft PR #11 opened from `codex-dev` into `main` |
 

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -44,7 +44,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
 | Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers retargeted |
 | Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
-| PR update | NEXT | Open or update PR into `main` after push |
+| PR update | DONE | Draft PR #11 opened from `codex-dev` into `main` |
 
 ## Open Follow-Ups
 

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-Parser reliability for uploaded `WoWCombatLog.txt` files, with Skada-aligned metric documentation, better malformed-line handling, and evidence-first difficulty segmentation.
+Local development has moved from the OneDrive Desktop checkout to the GitHub-backed checkout at `C:\Projects\PizzaLogs`, while parser reliability remains the current product focus.
 
 ## Current Branch Rule
 
@@ -23,6 +23,10 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Added focused parser tests for tokenization, damage, healing, malformed lines, explicit markers, heroic-to-normal fallback, and stream upload validation.
 - Updated README, parser contract docs, parser architecture notes, security checklist, decision log, and known issues.
 - Validation passed: full parser pytest suite, TypeScript type-check, ESLint, Next production build, and `git diff --check`.
+- Set up and validated `C:\Projects\PizzaLogs` as the local working checkout.
+- Copied local env files into the local checkout, installed dependencies, generated Prisma Client, and created a parser Python 3.12 virtualenv.
+- Retargeted the desktop Start/Stop launchers and `scripts/desktop/*.cmd` templates to `C:\Projects\PizzaLogs`.
+- Verified `http://127.0.0.1:3001/` and `http://127.0.0.1:8000/health` from the new checkout.
 
 ## Next Actions
 
@@ -38,7 +42,8 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Heroic-to-normal regression | DONE | Later normal kills stay normal without direct heroic evidence |
 | Documentation update | DONE | README, parser contract, vault parser docs, security, decision log, known issues |
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
-| Branch publication | NEXT | Commit and push `codex-dev` |
+| Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers retargeted |
+| Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
 | PR update | NEXT | Open or update PR into `main` after push |
 
 ## Open Follow-Ups
@@ -51,6 +56,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Add anonymized larger upload fixtures if Neil can provide safe samples.
 - If the laptop port changes from `3001`, add matching local roster/gear userscript variants or update the local constants.
 - If the Desktop launcher copies drift, update `scripts/desktop/*.cmd` and copy them back to `C:\Users\neil_\OneDrive\Desktop`.
+- If DB-backed local routes return 500, start PostgreSQL service `postgresql-x64-16` from an elevated shell or by running the Start launcher as administrator.
 
 ## Reference
 

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-04-30 - add-native-player-gear.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-04-30 - add-native-player-gear.md
@@ -1,0 +1,1545 @@
+# Add native player gear
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-04-30
+- Thread id: `019ddc71-39fc-7f12-bfc7-bf93bfd03adc`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\04\30\rollout-2026-04-30T00-31-41-019ddc71-39fc-7f12-bfc7-bf93bfd03adc.jsonl`
+- Imported user turns: 47
+- Imported assistant final replies: 44
+- Tool/command events omitted: 447
+
+## Discussion Digest
+
+## User
+
+[@superpowers](plugin://superpowers@openai-curated) Lets build a new feature:
+
+You are working in my existing Pizza Logs codebase.
+
+Build a native player gear feature for the player detail page.
+
+Context:
+- Current app: Pizza Logs
+- Production example player page:
+  https://pizza-logs-production.up.railway.app/players/Ashien
+- Warmane Armory source example:
+  https://armory.warmane.com/character/Ashien/Lordaeron/summary
+- Target realm: Lordaeron
+- This must NOT be an iframe.
+- This must scrape/read Warmane Armory data server-side and render it natively in Pizza Logs.
+
+Goal:
+When viewing a player page, fetch that characterâ€™s current gear from Warmane Armory and display it as part of the native player profile UI.
+
+Requirements:
+1. Add a server-side Warmane Armory scraper/service.
+2. Given a character name and realm, fetch:
+   - Equipped item slots
+   - Item names
+   - Item quality/rarity if available
+   - Item level if available
+   - Enchants/gems if visible/available
+   - Item icon if available
+   - Link back to the Warmane item/armory source where possible
+3. Integrate the gear data into the existing `/players/[name]` page.
+4. Use the player name from the route.
+5. Default realm should be `Lordaeron`.
+6. Render the gear in a clean native component, not an iframe.
+7. Match the existing Pizza Logs visual style.
+8. Add loading, empty, and error states.
+9. If Warmane blocks, changes markup, or the character does not exist, fail gracefully.
+10. Do not break existing player parsing, rankings, logs, or stats functionality.
+
+Implementation expectations:
+- Inspect the current project structure first.
+- Identify the framework, routing model, API pattern, and existing data fetching conventions.
+- Follow existing component and styling patterns.
+- Keep scraping logic isolated in a reusable module, for example:
+  `lib/warmane-armory.ts`
+  or the closest equivalent in this codebase.
+- Add an API route only if it fits the current architecture.
+- Avoid scraping from the browser. Scraping must happen server-side.
+- Add reasonable caching so the player page does not hit Warmane on every request.
+  Suggested cache duration: 6 to 24 hours.
+- Add timeout handling.
+- Add user-agent headers.
+- Validate and sanitize character names before building the Warmane URL.
+- Keep the feature read-only.
+
+Suggested data shape:
+
+```ts
+type ArmoryGearItem = {
+  slot: string;
+  name: string;
+  quality?: string;
+  itemLevel?: number;
+  iconUrl?: string;
+  itemUrl?: string;
+  enchant?: string;
+  gems?: string[];
+};
+
+type ArmoryCharacterGear = {
+  characterName: string;
+  realm: string;
+  sourceUrl: string;
+  fetchedAt: string;
+  items: ArmoryGearItem[];
+};
+
+UI requirements:
+
+Add a â€œGearâ€ section on the player detail page.
+Display gear by slot, preferably in a character-sheet style layout.
+Each item should show:
+Slot name
+Icon
+Item name
+Item level if available
+Gems/enchant if available
+Use item quality coloring if available.
+Include a small â€œSource: Warmane Armoryâ€ link.
+If no gear is found, show:
+â€œNo gear data available from Warmane Armory.â€
+If fetch fails, show a non-blocking message and still render the rest of the player page.
+
+Technical constraints:
+
+Do not use an iframe.
+Do not add a large scraping framework unless needed.
+Prefer lightweight HTML parsing such as cheerio if the project already supports Node server-side code.
+Keep dependencies minimal.
+Do not expose internal scraping errors to the user.
+Log useful server-side errors for debugging.
+Make sure this works on Railway deployment.
+
+Acceptance criteria:
+
+Visiting /players/Ashien shows the existing player page plus a native Gear section.
+Gear is fetched from:
+https://armory.warmane.com/character/Ashien/Lordaeron/summary
+The Warmane page is not embedded.
+Gear still renders after refresh using cached data when possible.
+If Warmane is down or markup changes, the page does not crash.
+Existing tests/build/lint pass.
+
+Before coding:
+
+Inspect the existing codebase.
+Identify the current player page implementation.
+Identify whether server-side rendering, API routes, or loaders are being used.
+Propose the smallest safe implementation plan.
+Then implement it.
+
+After coding:
+
+Run lint/typecheck/build/tests if available.
+Provide a concise summary of changed files.
+Explain how the scraper works.
+List any Warmane markup assumptions.
+Mention any follow-up improvements, such as historical gear snapshots or refresh buttons.
+
+## Assistant
+
+Implemented the native player Gear feature.
+
+Changed files:
+- [lib/warmane-armory.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-armory.ts)
+- [PlayerGearSection.tsx](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerGearSection.tsx)
+- [page.tsx](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/players/[playerName]/page.tsx)
+- Updated vault handoff/current focus/known issues files.
+
+How it works:
+- Server-side only, no iframe.
+- Fetches Warmane character summary data from `https://armory.warmane.com/api/character/<name>/<realm>/summary`.
+- Defaults realm to `Lordaeron`.
+- Sanitizes character names before URL construction.
+- Uses timeout, user-agent headers, server-side error logging, and 12-hour Next cache via `unstable_cache`.
+- Renders gear in a native `AccordionSection` with loading skeleton, empty state, and non-blocking error state.
+
+Warmane assumptions:
+- Equipment is read from the APIâ€™s `equipment` array, documented in Warmane forum examples: [Warmane API thread](https://forum.warmane.com/showthread.php?t=383159).
+- Slot names are inferred from the standard equipment order because the API examples expose item name/id/transmog but not explicit slot labels.
+- Item level, quality, icons, gems, and enchants are optional and render only if Warmane exposes them.
+
+Verification:
+- `tsc --noEmit` passed.
+- `next build` passed.
+- `next lint` could not run because this project has no ESLint config and Next prompted interactively to create one.
+
+One important caveat: direct local requests to Warmane returned Cloudflare/403 in this environment, so `/players/Ashien` may show the graceful unavailable state until verified from Railway production egress. Follow-ups: add item enrichment from a reliable item DB, historical gear snapshots, and possibly a manual refresh action.
+
+## User
+
+whats next?
+
+## Assistant
+
+Next best move: deploy/verify the gear feature on Railway, because the only real unknown is whether Warmane allows requests from Railway even though it blocked this local shell.
+
+Suggested order:
+
+1. Commit the gear feature plus vault updates.
+2. Deploy to Railway.
+3. Visit `/players/Ashien`.
+4. Confirm one of two outcomes:
+   - Gear renders from Warmane, great.
+   - Graceful â€œtemporarily unavailableâ€ state appears, meaning Warmane blocks Railway too.
+
+If Railway is blocked, the next implementation step is an enrichment/proxy strategy: either find a Warmane-accessible endpoint/source that Railway can reach, or add a small cached/manual refresh pipeline that can tolerate Warmaneâ€™s Cloudflare behavior. After that, we can enrich item icons, quality, ilvl, gems, and enchants more fully.
+
+Parser-wise, the repoâ€™s prior next priority is still the HC/Normal difficulty detection regression.
+
+## User
+
+then lets do it
+
+## Assistant
+
+Done. I committed and pushed the gear feature to `main`.
+
+Production `/players/Ashien` is now serving the new Gear section, and Railway can render the page. Warmane is blocking the server-side gear fetch from production too, so the section currently shows the graceful fallback: â€œGear data is temporarily unavailable from Warmane Armory,â€ with the Warmane source link. That means the UI/deploy path is good; the remaining problem is Warmane access/enrichment.
+
+Verified:
+- `tsc --noEmit` passed
+- `next build` passed
+- Commit: `4b2ae88 feat: add Warmane gear to player profiles`
+- Pushed to `origin/main`
+
+Unrelated local files are still untouched: `.obsidian` workspace/graph, `.next-dev*.log`, and `tmp-mobile-check/`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+it should just pull right? i dont want to have to upload a new file. it should just work with the data already in the DB
+
+## Assistant
+
+Yes, exactly: you should not need to upload a new file.
+
+Whatâ€™s happening on that page:
+
+- Pizza Logs finds `Aalaska` from the existing DB.
+- It uses that DB player name + realm `Lordaeron`.
+- It tries to pull current gear from Warmane Armory server-side.
+- Warmane is blocking the server request, so the Gear section falls back to the unavailable message.
+
+The combat-log DB does not contain equipped gear, so there is no gear data to â€œpullâ€ from Pizza Logs yet. The DB only has players, encounters, rankings, logs, stats, etc. Gear has to come from Warmane, then we can cache/store it.
+
+Best next fix: add a real persistent `ArmoryGearCache` table in the DB. Then the page can:
+
+1. Look up cached gear for the player.
+2. If fresh, render it immediately.
+3. If stale/missing, try Warmane in the background/server path.
+4. If Warmane blocks, keep showing the last cached gear instead of the error.
+
+That still needs Warmane to succeed at least once, but after that it wonâ€™t disappear every time Warmane blocks. Right now we only have Nextâ€™s server cache, not a DB-backed gear cache.
+
+## User
+
+is this the best approach?
+
+## Assistant
+
+Mostly yes, but with one important adjustment: **DB-backed gear cache is the best production shape**, but it is not enough by itself if Warmane blocks every server request forever.
+
+Best approach:
+
+1. **Keep gear separate from combat logs**
+   Gear should not require uploading a new log. Logs prove raid performance; Warmane/Armory provides current character state.
+
+2. **Add a persistent `ArmoryGearCache` table**
+   Store by `characterName + realm`, with:
+   - source URL
+   - fetchedAt
+   - raw/normalized gear JSON
+   - fetch status/error reason
+   - maybe `expiresAt`
+
+3. **Render cached gear first**
+   If Pizza Logs already has gear for `Aalaska`, show it even if Warmane is down today.
+
+4. **Refresh server-side**
+   On stale/missing cache, try to refresh from Warmane. If it fails, do not break the page.
+
+5. **Add an admin/manual refresh path later**
+   If Warmane blocks Railway, an admin refresh button or small worker can retry. But the public player page should stay fast and stable.
+
+The risky part is relying only on live Warmane scraping during page render. The better mental model is: **Pizza Logs owns a cached snapshot of current gear, refreshed from Warmane when possible.**
+
+So yes: DB cache is the right next move. The follow-up question is whether Warmaneâ€™s data can be fetched reliably from any server-side path. If not, weâ€™ll need a fallback data source or a refresh workflow that can run from an allowed environment.
+
+## User
+
+lets try it
+
+## Assistant
+
+Implemented and pushed the DB-backed gear cache.
+
+What changed:
+- Added `ArmoryGearCache` Prisma table in [schema.prisma](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/prisma/schema.prisma).
+- Updated [warmane-armory.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-armory.ts) so player pages:
+  - read cached gear from DB first
+  - use fresh cache for 12 hours
+  - try Warmane only when missing/stale
+  - render stale cached gear if Warmane blocks refresh
+- Added a small stale-cache note in the Gear UI.
+- Added [warmane-armory-cache.test.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/warmane-armory-cache.test.ts).
+
+Verified:
+- cache fallback test passed
+- `prisma validate` passed
+- `tsc --noEmit` passed
+- `next build` passed
+- Pushed commit `e63c0e0 feat: persist Warmane gear cache`
+
+Production still shows â€œtemporarily unavailableâ€ for `Aalaska` because there is no first cached snapshot yet and Warmane is still blocking the server refresh. No new combat-log upload is needed, but we do need one successful gear seed/fetch for each character before the DB cache can help.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## Assistant
+
+Yep, that screenshot is the expected state after the cache change: the page is using existing DB player data, but there is still no cached gear snapshot for `Ashien`, and Warmane is blocking the live server fetch.
+
+So the feature is working structurally, but the data source is the blocker.
+
+What we have now:
+- Existing player DB data renders.
+- No combat-log upload required.
+- Gear section attempts Warmane.
+- If gear had been cached previously, it would render even while Warmane is blocked.
+- Since there is no cached row yet, it shows unavailable.
+
+Next practical move: build a **seed/import path** for gear data. Options:
+
+1. **Admin paste/import from Warmane API JSON**
+   Fastest and most reliable. You paste captured Warmane gear JSON for a character, Pizza Logs stores it in `armory_gear_cache`, and the profile renders it forever until refreshed.
+
+2. **Admin â€œrefresh gearâ€ button**
+   Cleaner UX, but it will still fail while Warmane blocks Railway.
+
+3. **Browser-assisted capture**
+   Since your browser can view Warmane, we can extract visible gear from the page or copied source and save it into Pizza Logs. This avoids server Cloudflare, but it needs a small admin/import workflow.
+
+Best next step is option 1: an admin-only gear import form. That gives us a working cache immediately and keeps the public player page read-only.
+
+## User
+
+can i automate this first step based on the players in the DB?
+
+## Assistant
+
+Yes, with one caveat: you can automate **which players to seed** from the Pizza Logs DB, but you still need a data path that Warmane allows.
+
+Best version:
+
+1. Query all players from the DB with realm `Lordaeron`.
+2. For each player, check `armory_gear_cache`.
+3. If missing/stale, enqueue a gear refresh attempt.
+4. Refresh attempts call Warmane server-side.
+5. If Warmane blocks, mark `lastAttemptAt` / `lastError` and keep going.
+
+That automates the batch, but it wonâ€™t magically bypass Warmane blocking. It will populate gear automatically only for requests Warmane allows.
+
+More robust version:
+
+- Add an **admin â€œSeed Gear Cacheâ€** action.
+- It loops over all DB players.
+- It rate-limits requests, maybe 1 every 5-10 seconds.
+- It stores successes in `armory_gear_cache`.
+- It records failures without breaking the batch.
+- Later, add cron/weekly refresh.
+
+This is worth doing. It gives you:
+- no per-player manual work
+- no combat-log uploads
+- clear visibility into which players cached successfully
+- a foundation for scheduled refreshes
+
+If Warmane blocks all Railway requests, the seed run will show all failures, and then weâ€™ll know we need browser-assisted import or another data source.
+
+## User
+
+sure lets try it
+
+## Assistant
+
+Built and pushed the automation.
+
+Whatâ€™s now in `main`:
+- `/admin` has a new **Warmane Gear Cache** section.
+- It has a **Seed Gear Cache** button.
+- The server action loops over up to 100 existing DB players.
+- For each player, it uses the player name + realm from the DB and tries to populate `armory_gear_cache`.
+- Successes and failures are counted; failures do not break player pages.
+
+Verified locally:
+- cache fallback test passed
+- `prisma validate` passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+Pushed:
+- `53fcbe6 feat: add admin gear cache seeding`
+
+One wrinkle: production `/admin` has not picked up `53fcbe6` yet after polling. GitHub has the commit, so either Railway is still deploying slowly or auto-deploy did not trigger. Once Railway deploys it, go to `/admin` and look for **Warmane Gear Cache â†’ Seed Gear Cache**.
+
+Unrelated local files remain untouched: `.obsidian`, `.next-dev*.log`, `tmp-mobile-check/`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## Assistant
+
+Yep, that confirms the automation ran and answered the key question:
+
+- Attempted: `38`
+- Cached: `0`
+- Failed: `38`
+
+So Railway/server-side Warmane access is blocked for every current DB player. The player page and cache system are working; the missing piece is a first-fill data source that is not blocked.
+
+Best next step: add an **admin import box** for gear snapshots. Since your browser can open Warmane, we can make it so you paste copied Warmane/API/HTML data for a character, and Pizza Logs normalizes + stores it in `armory_gear_cache`. Then `/players/Ashien` renders from the DB cache without relying on Railway reaching Warmane.
+
+After that, we can make it nicer:
+- browser-assisted extraction instructions
+- bulk paste for multiple players
+- CSV/JSON import
+- eventually a browser extension/bookmarklet if needed
+
+The server batch seed was worth trying; now we know itâ€™s a hard Warmane block from production.
+
+## User
+
+can we automate this as well?
+
+## Assistant
+
+Yes. The right automation is **browser-side capture**, not Railway-side scraping.
+
+Since your browser can load Warmane but Railway cannot, we can add an admin workflow like this:
+
+1. `/admin` shows players missing cached gear.
+2. Click **Open Warmane Queue** or one player link.
+3. On the Warmane character page, run a small bookmarklet/userscript.
+4. It reads the visible gear from the Warmane page in your browser.
+5. It POSTs normalized gear back to Pizza Logs admin.
+6. Pizza Logs stores it in `armory_gear_cache`.
+7. Player pages render gear from DB after that.
+
+Best version: add a **Pizza Logs Gear Import Bookmarklet** on `/admin`.
+
+You drag/save it once, then for each Warmane character page you click it. We can later make it bulk-ish by opening the next missing player automatically after each successful import.
+
+This avoids:
+- new combat-log uploads
+- Railway needing Warmane access
+- iframes
+- manual copy/paste per item
+
+It does require your browser to visit Warmane pages because thatâ€™s the environment Warmane currently allows.
+
+## User
+
+lets try
+
+## Assistant
+
+Done. I added and pushed the browser-side automation.
+
+New commit:
+- `a4931a8 feat: add browser gear import bookmarklet`
+
+What it adds:
+- `/admin` now has a **Browser Gear Import** bookmarklet.
+- New endpoint: `POST /api/admin/armory-gear/import`
+- The bookmarklet is meant to be run while youâ€™re on a Warmane character summary page.
+- It scans visible Warmane item links, prompts for your Pizza Logs admin secret, and imports the gear into `armory_gear_cache`.
+- Then the Pizza Logs player page renders from the DB cache.
+
+Verified:
+- import normalization test passed
+- cache fallback test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+Production hasnâ€™t picked up `a4931a8` yet in my polling, so wait for Railway to deploy. Once it does:
+
+1. Go to `/admin`.
+2. Find **Browser Gear Import**.
+3. Drag **Pizza Logs Gear Import** to your bookmarks bar.
+4. Open a Warmane character page, like `Ashien`.
+5. Click the bookmarklet.
+6. Enter the admin secret.
+7. Refresh the Pizza Logs player page.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+yeah not sure this is the play.. either didnt work correctly or i didnt so it right but seems way too manual...
+
+https://forum.warmane.com/showthread.php?t=463405
+
+doesnt anything here help?
+
+## User
+
+here is a forum post doesnt it help?
+
+Warmane API Feedback
+Hello, I have recently tried to use Warmane API ( How to use Warmane API ) and have some notes from it I want to share (with anyone trying to do the same).
+
+API URLs
+
+http://armory.warmane.com/api/guild/Hardmode/Icecrown/summary
+http://armory.warmane.com/api/character/Dojun/Icecrown/summary
+The character and guild above are not mine, just a character I have seen in-game and used for some testing
+A space in name (seen only in guild) must be replaced by a plus sign (while when encoding for URL, you would use %20
+You can omit the /summary and it will still work
+
+
+The API is equivalent to
+https://armory.warmane.com/guild/Hardmode/Icecrown/summary
+https://armory.warmane.com/character/Dojun/Icecrown/summary
+Implementation notes
+
+Some numeric values are in quotes (=string) but a null (still present) when zero (seen with achievementpoints and talent points)
+transmog for items is always empty (you can try with the example above, Dojun has several transmogs but none of them visible)
+Character professions in Guild API are inside professions object (a wrapper) which may make your parsing little more difficult (or different than Character API, I had to add workaround for C# JsonSerializer)
+In case of an error, HTTP code is still 200 OK but the JSON is in {"error":"123"} (at least in case of too many requests)
+
+
+API Change suggestions
+
+Not ordered by "priority", just by me remembering them.
+
+Make numeric values numeric (not a number inside a string or a null)
+Say what delay between API calls should be used (not minimum, but expected)
+Provide official and up-to-date documentation and rules about the API
+Document possible Error Codes
+Include secondary professions (especially Cooking as Fish Feast requires Cooking 425 which some 10player raids may want to check for)
+Fix item transmog (not being filled in)
+Add lastonline as an addition to online (if privacy is a concern, you can decrease precision over time - <4 hours = minutes precision, <7 days = hour precision, <31 days = day precision, then just year and month)
+May help with Guild Cleanup of old, unused characters
+Include slot, type and itemlevel for items to allow GearScore calculation (or do it yourself)
+trempa18 recommends Cavern of Time API for item details but it is intended for websites
+You can probably use Trinity Core's item_template for non-website projects
+Include Raid ID expiration date
+To help filling-in few missing spots in raids
+May also provide Heroic Dungeon ID expiration but I would argue against it due to the amount of requests needed (unless it would be a separate "batch" API)
+Guild per-character rank and description (unless considered private?)
+Some guilds use EPGP which is stored in the description
+Rank can be useful to know who can recruit to the guild
+Guild MOTD (unless considered private?)
+Guild leader can either be removed (if you provide ranks) or just a character name (as you can find them in the roster where are more information about them)
+Include character location (especially in Guild endpoint, or new "guild online-only endpoint")
+Also suggested by trempa18, for tracking whenever a raid already started (or who did not come)
+I would like to see something like {"continent":"Northrend", "zone":"Wintergrasp"} (with tags dungeon and raid present when applicable) but I am also worried about player tracking (would require API "key", like Guild MOTD, character ranks and descriptions...)
+Include which talents the character has (not just a per-tree number)
+To distinct PvE from PvP (or whenever DK Blood is a Tank or DPS)
+Maybe even Glyphs for the sake of completion
+
+
+Class and Race Masks
+
+I don't know why they are there or why they are "masks" (suggesting you can be both Human and Dwarf?) but those are values I got from Icecrown:
+1 = Warrior
+2 = Paladin
+4 = Hunter
+8 = Rogue
+16 = Priest
+32 = Death Knight
+64 = Shaman
+128 = Mage
+256 = Warlock
+1024 = Druid
+1 = Human
+2 = Orc
+4 = Dwarf
+8 = Night Elf
+16 = Undead
+32 = Tauren
+64 = Gnome
+128 = Troll
+512 = Blood Elf
+1024 = Dranei
+You can see 512 missing for classes and 256 for races, I could not find anything with those values.
+
+ December 30, 2023
+Shred's Avatar
+Shred
+Rock n' Roll Racing Champion
+Class 512 does not exist in wotlk (it was meant to be monk) and race 256 is goblin (not playable)
+
+Numbers are taken directly from dbc databases.
+
+They are masks because you can add all the masks for alliance races and check whether a race belongs to the alliance faster. Or whether someone's class is valid. You can see that in the trinity code.
+
+## Assistant
+
+Yes, the forum post helps. It confirms the best route is Warmaneâ€™s JSON API, not scraping visible HTML.
+
+I tested the API from this machine with both:
+
+- `http://armory.warmane.com/api/character/Ashien/Lordaeron/summary`
+- `https://armory.warmane.com/api/character/Ashien/Lordaeron/summary`
+
+Both are still Cloudflare-blocked from server-side requests. But the post gives us the better browser-side play: from a Warmane page, the browser can call `/api/character/...` as same-origin JSON.
+
+I updated and pushed that approach:
+
+- New commit: `1caa4df feat: bulk import Warmane gear via browser API`
+- The `/admin` bookmarklet now has a **bulk importer**.
+- Run it from any Warmane Armory page.
+- It asks Pizza Logs for missing DB players.
+- Then it fetches each character from Warmaneâ€™s API in your browser.
+- Then it posts the JSON back into Pizza Logs cache.
+- The old single-page fallback still exists.
+
+Verified:
+- import test passed
+- cache test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+Once Railway deploys this, use the updated `/admin` bookmarklet, not the previous one. The important thing is to recreate/replace the bookmarklet from the new admin page, because the old saved one still has the manual scrape behavior.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## Assistant
+
+That error is on me, not you. React blocks rendered `javascript:` links now, so clicking the bookmarklet from the admin page triggers that security warning.
+
+I fixed it and pushed:
+
+- `f78d382 fix: make gear bookmarklet copyable`
+
+After Railway deploys, `/admin` will show a **Bulk bookmark URL** text box instead of a clickable bookmarklet. Use it like this:
+
+1. Copy the full code from **Bulk bookmark URL**.
+2. Create/edit a browser bookmark.
+3. Paste that code into the bookmarkâ€™s URL field.
+4. Open any `armory.warmane.com` page.
+5. Click the bookmark.
+6. Enter the Pizza Logs admin secret.
+
+Verified before push:
+- import test passed
+- cache test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+Can you also please clean up the other failed attempts or at least explain to me the various features on the admin screen now around this gear view feature
+
+## Assistant
+
+Cleaned it up and pushed:
+
+- `0d7e5ed chore: simplify gear admin workflow`
+
+What I removed:
+- The failed **Seed Gear Cache** button.
+- The server-side batch seed action.
+- The misleading â€œBatch Sizeâ€ card.
+- The admin screen no longer suggests Railway can pull Warmane gear directly.
+
+What remains on the admin gear section:
+
+- **Cached Characters**: how many player gear snapshots are stored in `armory_gear_cache`.
+- **Server Refresh Errors**: leftover diagnostic count for direct server refresh failures.
+- **Browser Gear Import**: the real supported path. Copy the bulk bookmark URL into a browser bookmark, open any Warmane Armory page, click it, and it imports missing DB players through Warmaneâ€™s browser-accessible API.
+
+Why this is the right shape:
+- Public player pages stay read-only and use cached gear.
+- No new combat-log upload needed.
+- Railway is no longer expected to beat Warmaneâ€™s Cloudflare block.
+- The only â€œmanualâ€ part left is one-time bookmark setup plus running it from Warmane.
+
+Verified:
+- import test passed
+- cache test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+can we not just use the api call to pull back the JSON then parse the json and populate the UI all in one go on the individual player pages?
+
+## Assistant
+
+That was actually the first thing I built.
+
+The player page does exactly that already:
+
+1. Reads the player name from `/players/[name]`.
+2. Builds the Warmane API URL:
+   `https://armory.warmane.com/api/character/<name>/Lordaeron/summary`
+3. Fetches it server-side.
+4. Parses the JSON.
+5. Normalizes `equipment`.
+6. Renders the Gear UI.
+
+The reason it doesnâ€™t show gear is not code flow. Itâ€™s that Warmane blocks the request when it comes from Railway/server-side:
+
+- Local server request: `403 Cloudflare challenge`
+- Railway player page request: same issue
+- Admin server batch seed: `38 attempted; 0 cached; 38 failed`
+
+The browser can view Warmane because your browser has passed Cloudflare. Railway has not. A Next.js player page server component runs on Railway, not in your browser, so it hits the block.
+
+Could we fetch Warmane directly from the browser on each player page instead? Probably not cleanly:
+- Warmane likely wonâ€™t allow cross-origin browser fetches from `pizza-logs-production.up.railway.app`.
+- Even if it did, it would expose the dependency to every visitor and be slower/flakier.
+- It would still not be â€œserver-sideâ€ as originally required.
+
+So the possible architectures are:
+
+1. **Server-side live API fetch**: best UX, already implemented, blocked by Warmane.
+2. **Browser-side live fetch from Pizza Logs page**: likely blocked by CORS, and not server-side.
+3. **Browser-assisted import from Warmane origin**: works around Cloudflare by using your browser on Warmane, then stores JSON in Pizza Logs DB.
+4. **External worker/proxy with allowed Warmane access**: possible, but more infrastructure and still subject to Warmane blocking/rate limits.
+
+So yes, your idea is the ideal path, and itâ€™s already in the code. The environment is the problem: Warmane wonâ€™t give Railway the JSON.
+
+## User
+
+what does teh api show then?
+
+## Assistant
+
+The Warmane character API returns a JSON profile summary. The useful part for gear is an `equipment` array.
+
+Based on the Warmane forum post and the API examples, itâ€™s roughly shaped like:
+
+```json
+{
+  "name": "Ashien",
+  "realm": "Lordaeron",
+  "level": "80",
+  "race": "1",
+  "class": "2",
+  "gender": "0",
+  "guild": "...",
+  "achievementpoints": "...",
+  "professions": [...],
+  "talents": {...},
+  "equipment": [
+    {
+      "name": "Item Name",
+      "item": "12345",
+      "transmog": ""
+    }
+  ]
+}
+```
+
+For gear, the important bit is:
+
+```json
+"equipment": [
+  {
+    "name": "Sanctified Lightsworn Headpiece",
+    "item": "51272",
+    "transmog": ""
+  }
+]
+```
+
+What it gives us:
+- item name
+- item ID
+- equipment array order, which we map to slots like Head, Neck, Shoulder, etc.
+- sometimes character metadata like class/race/guild/professions/talents
+
+What it apparently does **not** give us:
+- explicit slot name
+- item level
+- gems
+- enchants
+- item quality
+- icon URL
+- reliable transmog data
+
+The forum post specifically says item `transmog` is always empty and suggests Warmane should add `slot`, `type`, and `itemlevel`, which implies they are not currently in the API.
+
+So the API is enough to render a basic gear list:
+
+```txt
+Head: Sanctified Lightsworn Headpiece
+Neck: Some Necklace
+Shoulder: Some Shoulders
+...
+```
+
+But for a rich character sheet with icons, colors, ilvl, gems, enchants, we need enrichment from another item source after we get the Warmane `item` IDs.
+
+## User
+
+oh then use wowhead to parse the item?
+
+## Assistant
+
+Yes. Thatâ€™s the right enrichment layer.
+
+The clean split should be:
+
+1. **Warmane API**
+   Use it for â€œwhat is this character wearing?â€
+   It gives item IDs and names in `equipment`.
+
+2. **Wowhead WotLK tooltip/item endpoint**
+   Use it for â€œwhat is this item?â€
+   From item ID, pull:
+   - icon
+   - quality/color
+   - item level, if exposed in tooltip HTML/JSON
+   - maybe slot/type
+   - maybe tooltip text
+
+3. **Pizza Logs DB cache**
+   Store the enriched result so player pages donâ€™t hit Warmane/Wowhead every render.
+
+The likely endpoint is something like:
+
+```txt
+https://www.wowhead.com/wotlk/tooltip/item/51272&json
+```
+
+or a variant with level/bonus params. Wowheadâ€™s own tooltip docs confirm they support external item tooltips, and I found examples of the WotLK tooltip JSON endpoint being used.
+
+Caveats:
+- Wowhead will enrich item metadata, but it cannot know Ashienâ€™s exact gems/enchants unless Warmaneâ€™s API includes those IDs. The forum post suggests Warmane currently does **not** expose gems/enchants/itemlevel/slot.
+- So Wowhead helps a lot for icons/quality/base ilvl/tooltip, but not player-specific socket/enchant state unless that data exists upstream.
+
+Best next move:
+- Add `lib/wowhead-items.ts`.
+- Given Warmane item IDs, fetch/cache Wowhead tooltip data.
+- Enrich gear cards with icon, quality, ilvl/slot if available.
+- Keep this separate from the Warmane character fetch so failures donâ€™t break gear rendering.
+
+## User
+
+looks like this https://www.wowhead.com/wotlk/item=51167/sanctified-lightsworn-headpiece
+
+## Assistant
+
+Yep, thatâ€™s the normal Wowhead item page URL format:
+
+```txt
+https://www.wowhead.com/wotlk/item=51167/sanctified-lightsworn-headpiece
+```
+
+For Pizza Logs we can generate that directly from Warmaneâ€™s item ID and item name:
+
+```ts
+const wowheadUrl =
+  `https://www.wowhead.com/wotlk/item=${itemId}/${slugify(itemName)}`;
+```
+
+That gives us a good item link even without scraping Wowhead.
+
+For icons/quality/item level, weâ€™d still want the tooltip JSON endpoint, likely:
+
+```txt
+https://www.wowhead.com/wotlk/tooltip/item/51167&json
+```
+
+So the enriched item shape becomes:
+
+```ts
+{
+  slot: "Head",
+  name: "Sanctified Lightsworn Headpiece",
+  itemUrl: "https://www.wowhead.com/wotlk/item=51167/sanctified-lightsworn-headpiece",
+  iconUrl: "...",
+  quality: "epic",
+  itemLevel: 264
+}
+```
+
+This is much better than linking back to Warmane item pages. Use Warmane for character equipment, Wowhead for item metadata.
+
+## User
+
+do it please and clean up the admin. i want this to be seemless and fully automated.
+
+## User
+
+so this custom bookmarlet url does work. it fails on a few accounts every time but eventually after you keep doing it it will get them all. not ideal but works.
+
+Gear page isnt bad but I dont want the click to go anywhere and I want there to be a hover over with all of the details of the piece and also the gear icon. Use wowhead for this
+
+## Assistant
+
+Implemented and pushed: `d42f193 feat: enrich gear items with Wowhead details`.
+
+What changed:
+- Gear item cards no longer click out anywhere.
+- Cards now show native Pizza Logs hover/focus tooltips with Wowhead-enriched details.
+- Wowhead enrichment parses item page data for icon, quality, item level, item URL, and tooltip text.
+- Warmane browser-imported gear is enriched before saving to the DB cache.
+- Admin remains cleaned up: bookmarklet import is still the practical fallback since Warmane blocks server-side requests.
+
+Verification passed:
+- `tests/wowhead-items.test.ts`
+- `tests/warmane-armory-import.test.ts`
+- `tests/warmane-armory-cache.test.ts`
+- `tsc --noEmit`
+- `next build`
+
+One important caveat: existing cached gear rows wonâ€™t magically gain Wowhead details until theyâ€™re re-imported or refreshed. Running the bookmarklet again should rewrite/enrich those cached snapshots.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## Assistant
+
+That screenshot made sense: the importer only looked for players with no cache row. Your existing rows were cached before Wowhead enrichment existed, so it said â€œno uncached playersâ€ even though those rows still needed upgrading.
+
+Fixed and pushed: `a692654 fix: requeue cached gear needing enrichment`.
+
+Now the bookmarklet queue includes:
+- players with no gear cache row
+- players with cached gear that lacks Wowhead item IDs/icons/item level/details
+
+After Railway deploys this commit, run the same bulk bookmarklet again. It should re-import/enrich the older cached rows instead of saying thereâ€™s nothing to do.
+
+Verified:
+- `warmane-armory-import` test passed
+- `wowhead-items` test passed
+- `warmane-armory-cache` test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+scrape custom url keeps failing
+
+## Assistant
+
+Yep, I think the issue is the bookmarklet is too fragile for Warmaneâ€™s flaky per-character API reads, and the saved custom URL is a static copy.
+
+I pushed a fix: `791edfd fix: retry Warmane browser gear imports`.
+
+What changed:
+- Bulk and single-character bookmarklets now retry each Warmane fetch up to 4 times.
+- Retries use backoff instead of immediately marking the player failed.
+- Final alert now lists failed character names and errors.
+- Admin copy now says to replace the bookmark URL after deploys.
+
+Important next step: after Railway deploys, go to `/admin`, copy the updated bulk bookmark URL, and replace your existing `Scrape` bookmark URL. The old bookmark will keep running old code forever.
+
+Verified:
+- `tsc --noEmit`
+- `warmane-armory-import` test
+- `wowhead-items` test
+- `next build`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+scrap works gear on player page works. not seeing enchants or gems though anyway to get that from warmane maybe?
+
+## Assistant
+
+Short answer: probably not reliably from Warmane right now.
+
+What we have:
+
+- Warmane API gives equipped item IDs/names, but not character-specific gems/enchants.
+- Wowhead can give base item info: icon, quality, ilvl, socket colors, socket bonus, stats. It cannot know what gem/enchant your character actually has.
+- Warmane forum history suggests gems/enchants have been missing/broken in the armory/API for a while: [armory not showing gems/enchants](https://forum.warmane.com/showthread.php?t=464966), [API missing gems/enchants](https://forum.warmane.com/showthread.php?t=383159).
+
+The only possible Warmane path would be a best-effort browser scrape from the visible character page/tooltip, if Warmane embeds gem/enchant data in the page HTML or hover tooltip. But from what weâ€™ve seen, the API does not include it, and the site itself may not expose it consistently.
+
+My recommendation: for now, use Wowhead to show socket colors/socket bonus/base item details, but donâ€™t label real gems/enchants unless Warmane actually provides them. The more reliable future path would be an optional in-game addon/export snapshot, but that stops being seamless.
+
+## User
+
+can the scrape happen automatically? like why do i have to use that custom bookmarklet on the armory page
+
+## Assistant
+
+Mostly: not from Railway, because Warmane blocks server-side requests with Cloudflare/403. Thatâ€™s why the bookmarklet works: it runs inside your normal browser while youâ€™re already on `armory.warmane.com`, so the request comes from Warmaneâ€™s own origin/session instead of Pizza Logsâ€™ server.
+
+So the options are:
+
+1. **Fully automatic server cron**
+   - Best UX.
+   - Currently blocked unless Warmane allows Railway/server traffic.
+   - Pizza Logs already tries this path gracefully, but Warmane denies it.
+
+2. **Bookmarklet**
+   - Annoying/manual.
+   - Works because your browser can access Warmane.
+   - Lowest complexity, no extension install.
+
+3. **Browser extension / userscript**
+   - Best middle ground.
+   - Could automatically run when you visit Warmane Armory, or add a real button.
+   - Still uses your browser access, but feels less clunky than a bookmarklet.
+
+4. **Local scraper on your PC**
+   - Could run Playwright/Chrome locally and push to Pizza Logs.
+   - More moving parts, but can be scheduled.
+
+For truly seamless â€œplayer page loads, gear appears automatically,â€ we need Warmane to allow server-side API access from Railway. Since it doesnâ€™t, the bookmarklet is the workaround, not the ideal architecture.
+
+Best next upgrade: replace the bookmarklet with a tiny Chrome userscript/extension so it can auto-sync when youâ€™re on Warmane, without copying/running custom URLs.
+
+## User
+
+lets do that
+
+## Assistant
+
+Done and pushed: `c188bfe feat: add Warmane gear auto-sync userscript`.
+
+What changed:
+- `/admin` now recommends an automatic Tampermonkey/userscript instead of the bookmarklet.
+- The script injects a small â€œPizza Logs Gear Syncâ€ panel on Warmane Armory pages.
+- Click **Sync now** once to enter/save the admin secret.
+- After that, visiting Warmane Armory auto-syncs at most once per hour.
+- It still retries Warmane failures and imports missing or unenriched players.
+- Bookmarklet fallback remains available in a collapsed section.
+
+Verified:
+- `tsc --noEmit`
+- `warmane-armory-import`
+- `wowhead-items`
+- `warmane-armory-cache`
+- `next build`
+
+After Railway deploys, go to `/admin`, copy the new **Automatic userscript**, install/update it in Tampermonkey, then open any Warmane Armory page.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+where is the scipt hosted?
+
+## Assistant
+
+It isnâ€™t hosted as a separate `.user.js` URL yet.
+
+Right now itâ€™s generated inline on the `/admin` page:
+
+`/admin` â†’ **Warmane Gear Cache** â†’ **Automatic userscript** textarea
+
+You paste that code into Tampermonkey manually.
+
+A nicer next step would be to expose it at a real install URL, for example:
+
+`https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript`
+
+Then Tampermonkey can install/update it from a URL instead of copy-paste.
+
+## User
+
+lets do that
+
+## Assistant
+
+Done and pushed: `f24aca3 feat: host Warmane gear userscript`.
+
+The script is now hosted here:
+
+[https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript](https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript)
+
+After Railway deploys, `/admin` will show an **Install / Update Userscript** link pointing there. The script includes Tampermonkey `@downloadURL` and `@updateURL`, so updates can come from that hosted route.
+
+Verified:
+- `armory-gear-client-scripts` test
+- `warmane-armory-import` test
+- `wowhead-items` test
+- `warmane-armory-cache` test
+- `next build`
+- `tsc --noEmit` passed after build regenerated `.next/types`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+where do i go to host the script
+
+## Assistant
+
+You donâ€™t need to host it anywhere else. Pizza Logs hosts it now.
+
+Go here after Railway finishes deploying:
+
+[https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript](https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript)
+
+Or go to:
+
+[https://pizza-logs-production.up.railway.app/admin](https://pizza-logs-production.up.railway.app/admin)
+
+Then use the **Install / Update Userscript** link in the Warmane Gear Cache section.
+
+In Tampermonkey, that URL is the hosted script URL.
+
+## User
+
+so how di i know anything worked?
+
+## Assistant
+
+Youâ€™ll know in three places:
+
+1. **Tampermonkey install**
+   - Opening the hosted script URL should show Tampermonkeyâ€™s install/update screen.
+   - After installing, Tampermonkey should list **Pizza Logs Warmane Gear Auto Sync**.
+
+2. **Warmane page**
+   - Open any Warmane Armory page, like Ashien.
+   - You should see a small **Pizza Logs Gear Sync** panel in the bottom-right.
+   - First time, click **Sync now**, enter the Pizza Logs admin secret.
+   - The panel should say things like:
+     - `Checking Pizza Logs queue...`
+     - `Importing Aalaska (1/38)...`
+     - `Imported X; failed Y`
+     - or `No players need import or enrichment.`
+
+3. **Pizza Logs player page**
+   - Open a player page after sync:
+     [https://pizza-logs-production.up.railway.app/players/Ashien](https://pizza-logs-production.up.railway.app/players/Ashien)
+   - Gear should show icons.
+   - Hovering gear should show native item details.
+   - If gear already had data, the visible proof is icons/tooltips getting richer or the sync panel saying nothing needs import.
+
+If you donâ€™t see the bottom-right panel on Warmane, the userscript didnâ€™t install/run. If the panel appears but says unauthorized, reset the secret and enter it again.
+
+## User
+
+so i have the chrome extension for tampermonkey but when i click the install/update button nothing happens
+
+## Assistant
+
+That was likely on me: the install URL did not end in `.user.js`, and Tampermonkey often wonâ€™t intercept a plain JS route.
+
+I fixed and pushed: `6bc8425 fix: use userscript install extension`.
+
+After Railway deploys, use this URL instead:
+
+[https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js](https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js)
+
+The `/admin` button will point there too. The old `/userscript` route still exists, but the `.user.js` route is the one Tampermonkey should recognize.
+
+Verified:
+- userscript test passed
+- import test passed
+- `tsc --noEmit` passed
+- `next build` passed and listed `/api/admin/armory-gear/userscript.user.js`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+so the redirect worked and i installed how do i know its running on warmanes site
+
+## Assistant
+
+Open any Warmane Armory page, for example:
+
+[https://armory.warmane.com/character/Ashien/Lordaeron/summary](https://armory.warmane.com/character/Ashien/Lordaeron/summary)
+
+You should see a small **Pizza Logs Gear Sync** panel in the bottom-right of the page.
+
+What to check:
+
+1. **Panel appears**
+   - Bottom-right box says **Pizza Logs Gear Sync**.
+   - If you see it, the userscript is running.
+
+2. **First run**
+   - Click **Sync now**.
+   - It should ask for the Pizza Logs admin secret.
+   - After entering it, the panel should change status:
+     - `Checking Pizza Logs queue...`
+     - `Importing <name>...`
+     - `Imported X; failed Y`
+     - or `No players need import or enrichment.`
+
+3. **Tampermonkey icon**
+   - On the Warmane tab, click the Tampermonkey extension icon.
+   - It should list **Pizza Logs Warmane Gear Auto Sync** as active on this page.
+
+4. **Pizza Logs proof**
+   - Go to a Pizza Logs player page and confirm gear icons/tooltips are present:
+     [https://pizza-logs-production.up.railway.app/players/Ashien](https://pizza-logs-production.up.railway.app/players/Ashien)
+
+If the panel does not appear, refresh the Warmane page once. If it still does not appear, Tampermonkey is installed but the script is not enabled or doesnâ€™t have site access for `armory.warmane.com`.
+
+## User
+
+the tool tips were always there. via wowhead haha
+
+## Assistant
+
+Yep, fair catch. The â€œtooltips are presentâ€ check is too weak because Wowhead enrichment already gave you that.
+
+Better proof that the userscript is running:
+
+- On a Warmane Armory page, you should see the **Pizza Logs Gear Sync** panel in the bottom-right. That is the main signal.
+- Click Tampermonkey on that Warmane tab. It should show **Pizza Logs Warmane Gear Auto Sync** as active.
+- Click **Sync now** in the panel. You should see status text change to `Checking Pizza Logs queue...`.
+- If everything is already current, the success state is: `No players need import or enrichment.`
+- If work remains, it should show `Importing <name>...`.
+
+So ignore the Pizza Logs tooltip as a run check. The run check is the injected Warmane panel plus its sync status.
+
+## User
+
+guessing its not working?
+
+## Assistant
+
+Yeah, from that screenshot the panel is not running.
+
+I pushed a fix: `f02d1d3 fix: inject Warmane userscript reliably`.
+
+What changed:
+- Userscript now matches both:
+  - `https://armory.warmane.com/*`
+  - `http://armory.warmane.com/*`
+- Added `@run-at document-idle`
+- Script now waits for `document.body` before injecting the panel
+- Bumped userscript version to `1.0.2`
+
+After Railway deploys:
+1. Open Tampermonkey dashboard.
+2. Find **Pizza Logs Warmane Gear Auto Sync**.
+3. Use Tampermonkeyâ€™s update/check-for-updates, or reinstall from:
+   [https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js](https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js)
+4. Refresh the Warmane page.
+
+If it works, youâ€™ll see the **Pizza Logs Gear Sync** panel bottom-right. If not, click the Tampermonkey icon on the Warmane tab and check whether the script is listed as active.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+updated the script
+
+## Assistant
+
+Yep, based on that screenshot it still is not visibly running.
+
+I pushed `6093d5c chore: add userscript diagnostics`, version `1.0.3`.
+
+After Railway deploys, update the script again, then on the Warmane tab:
+
+1. Press `F12`
+2. Open **Console**
+3. Refresh the Warmane page
+4. Search/look for:
+
+`Pizza Logs userscript starting`
+
+Interpretation:
+
+- If you **do not see** `Pizza Logs userscript starting`, Tampermonkey is not running the script on Warmane. Then check:
+  - Tampermonkey icon on the Warmane tab
+  - script is enabled
+  - Chrome extension site access is allowed for `armory.warmane.com`
+  - Tampermonkey developer mode/user-scripts permission if Chrome asks for it
+
+- If you **do see** `Pizza Logs userscript starting` but no panel, look for:
+  - `Pizza Logs panel injection failed`
+
+That will tell us whether this is a Tampermonkey/site-access issue or a panel injection issue.
+
+Verified before push:
+- userscript test passed
+- import test passed
+- `tsc --noEmit` passed
+- `next build` passed
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+didnt see anything to do with a script just their own js issues
+
+## Assistant
+
+Yep, if thereâ€™s no `Pizza Logs userscript starting` log, then the userscript is not executing on the Warmane page at all. That means this is Tampermonkey/Chrome site access, not the sync code.
+
+I just pushed a diagnostic update: `6093d5c`, userscript `v1.0.3`.
+
+After Railway deploys, do this:
+
+1. Go to Tampermonkey dashboard.
+2. Open **Pizza Logs Warmane Gear Auto Sync**.
+3. Make sure version says `1.0.3`.
+4. If not, reinstall/update from:
+   [https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js](https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js)
+5. On the Warmane tab, click the Tampermonkey extension icon.
+6. Confirm it shows **Pizza Logs Warmane Gear Auto Sync** as enabled/running for this page.
+
+If the Tampermonkey popup does not show the script on that Warmane tab, check Chrome extension site access:
+- Extensions â†’ Tampermonkey â†’ Details
+- **Site access**: set to **On all sites** or allow `https://armory.warmane.com`
+- Also make sure Tampermonkey itself and the script are enabled.
+
+Once v1.0.3 is installed, refresh Warmane and look for `Pizza Logs userscript starting` in Console.
+
+## Assistant
+
+That DevTools window is for Tampermonkeyâ€™s extension background page, not the Warmane page. The `background.js` errors are Tampermonkey/Chrome extension noise, not our script.
+
+Open DevTools on the **Warmane tab itself**:
+
+1. Click the Warmane page tab.
+2. Press `F12` there, or right-click the Warmane page â†’ **Inspect**.
+3. In Console, the top-left dropdown should say something like `top` or the Warmane page, not `background.js`.
+4. Refresh the Warmane page.
+5. Look for `Pizza Logs userscript starting`.
+
+Also check the Tampermonkey popup while youâ€™re on the Warmane tab:
+- Click the Tampermonkey extension icon.
+- It should show **Pizza Logs Warmane Gear Auto Sync** under active scripts.
+- If it doesnâ€™t, the script isnâ€™t enabled for that site.
+
+The screenshot you sent doesnâ€™t prove failure yet; itâ€™s just the wrong DevTools context.
+
+## Assistant
+
+That dropdown is the useful clue: Tampermonkey is not listed there. Youâ€™re seeing other extensions like AdBlock, Bitwarden, Claude, but not **Tampermonkey** or **Pizza Logs Warmane Gear Auto Sync**.
+
+So the Pizza Logs script is not running on this Warmane tab yet.
+
+Check these in order:
+
+1. **Tampermonkey extension site access**
+   - Chrome â†’ Extensions â†’ Tampermonkey â†’ Details
+   - Set **Site access** to **On all sites**
+   - Or explicitly allow `https://armory.warmane.com`
+
+2. **Chrome developer mode / user scripts permission**
+   - Go to `chrome://extensions`
+   - Enable **Developer mode**
+   - Open Tampermonkey details
+   - If you see **Allow User Scripts** or similar, enable it
+
+3. **Tampermonkey dashboard**
+   - Open Tampermonkey dashboard
+   - Make sure **Pizza Logs Warmane Gear Auto Sync** is enabled
+   - Confirm it has:
+     - `@match https://armory.warmane.com/*`
+     - `@match http://armory.warmane.com/*`
+     - version `1.0.3`
+
+4. **Refresh Warmane**
+   - Reload the Warmane tab
+   - Click Tampermonkey icon while on that tab
+   - It should show the Pizza Logs script as active
+
+Once Tampermonkey appears as an extension context or the script appears in the Tampermonkey popup, then we can debug the script itself. Right now it hasnâ€™t made it onto the page.
+
+## Assistant
+
+Youâ€™re on the Tampermonkey reinstall screen. It is not updated until you click **Reinstall**.
+
+Click **Reinstall** in the top-right or the button near the script details.
+
+Then:
+
+1. Go back to the Warmane tab.
+2. Hard refresh: `Ctrl+F5`.
+3. Open DevTools Console on the Warmane tab.
+4. Look for:
+   `Pizza Logs userscript starting`
+5. Also look bottom-right for the **Pizza Logs Gear Sync** panel.
+
+One catch: Tampermonkey says â€œAll script settings will be reset,â€ so after reinstall youâ€™ll need to click **Sync now** and enter the admin secret again.
+
+## User
+
+i dont even have a sync now button on warmanes website though
+
+## Assistant
+
+Right, because the panel still hasnâ€™t injected. No panel = no **Sync now** button.
+
+From your last screenshot, the next immediate step is:
+
+1. On the Tampermonkey reinstall page, click **Reinstall**.
+2. Go back to the Warmane tab.
+3. Refresh the Warmane tab.
+4. Then check if the **Pizza Logs Gear Sync** panel appears bottom-right.
+
+If it still doesnâ€™t appear after reinstall, click the Tampermonkey extension icon while you are on the Warmane tab. It should show **Pizza Logs Warmane Gear Auto Sync** as running on that page.
+
+If it does not show there, the issue is Chrome/Tampermonkey permissions, not the Pizza Logs script.
+
+## Assistant
+
+There it is. Tampermonkey is enabled, and the Pizza Logs script is installed, but Chrome is blocking userscript injection because **Developer mode is off**.
+
+Do this:
+
+1. Open `chrome://extensions`
+2. Turn on **Developer mode** in the top-right.
+3. Go back to the Warmane tab.
+4. Refresh the page.
+5. The **Pizza Logs Gear Sync** panel should appear bottom-right.
+
+That blue Tampermonkey warning is the blocker. Once Developer mode is enabled, the installed script should actually inject.
+
+## User
+
+developer mode was already on
+
+## Assistant
+
+If Developer mode is already on but Tampermonkey still shows that banner, Chrome probably hasnâ€™t granted Tampermonkey the newer **User Scripts API** permission.
+
+Try this:
+
+1. Go to `chrome://extensions`
+2. Open **Tampermonkey â†’ Details**
+3. Look for either:
+   - **Allow User Scripts**
+   - **Allow access to User Scripts API**
+   - **Allow user scripts**
+4. Turn that on.
+5. Also set **Site access** to **On all sites**.
+6. Fully reload the Warmane tab.
+
+If you donâ€™t see that option, try disabling then re-enabling Tampermonkey after Developer mode is on. Chrome sometimes only exposes the permission after toggling the extension.
+
+Your Tampermonkey popup shows the script is installed and enabled, so the remaining blocker is Chrome/Tampermonkey injection permission, not the Pizza Logs code.
+
+## User
+
+ehhh
+
+## Assistant
+
+There we go. Thatâ€™s working now.
+
+The panel is injected and actively syncing:
+
+`Importing Rimeclaw (13/18)...`
+
+So the userscript is running, it has the secret, it fetched the Pizza Logs queue, and itâ€™s importing/enriching players through Warmane from your browser. Thatâ€™s the whole path we wanted.
+
+When it finishes, it should say something like:
+
+- `Imported 18; failed 0.`
+- or `Imported X; failed Y...`
+
+Then check Pizza Logs player pages for the newly cached gear.
+
+## User
+
+update your handoff and anything else you need to. gonna start a new session
+
+## Assistant
+
+Handoff is updated, committed, and pushed.
+
+Commit: `5e73f8a docs: update gear userscript handoff`
+
+I updated:
+- [Latest Handoff.md](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/Pizza Logs HQ/02 Build Log/Latest Handoff.md>)
+- [Now.md](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/Pizza Logs HQ/03 Current Focus/Now.md>)
+- [Known Issues.md](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md>)
+
+I left the unrelated local files alone: Obsidian workspace/graph changes, `.next-dev` logs, and `tmp-mobile-check/`.
+
+Next session should pick up with: let the Warmane userscript finish, spot-check player gear pages for icons/tooltips, then return to HC/Normal detection.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+found a bug here .. heroic scourgeborne Waraxes should be 531 x2 for hunters. this is an older session/chat within the project so make sure youre up to date
+
+## User
+
+hes 6237 in game. where am im missing this math from.
+
+## Assistant
+
+The missing math was hunter-specific weighting.
+
+Before the follow-up fix, Notlich was:
+
+- Waraxes displayed as `531 + 531`
+- But total still counted hunter melee as `168 + 168`
+- Ranged got boosted internally
+- Net result: `6,209`
+
+That hunter weighting came from GearScoreLite-style logic, but your in-game value is clearly using raw hunter weapon item scores instead. I removed hunter-only melee/ranged weighting from the total while keeping Titan Grip handling.
+
+Live production now shows:
+
+- Notlich summary: `6,235`
+- Scourgeborne Waraxe: `GS 531`
+- Scourgeborne Waraxe: `GS 531`
+
+Remaining difference from in-game `6,237` is now only `2`, which is likely formula constant/rounding/addon-version variance, not the hunter weapon weighting bug.
+
+Pushed to `origin/main`: `e00cb83 fix: show raw gearscore on item cards`
+
+Validated:
+- GearScore regression test passed
+- Typecheck passed
+- ESLint passed
+- Production build passed
+- Production `/players/Notlich` checked after deploy
+
+Reference checked for the original hunter weighting behavior: [TacoTip GearScore system notes](https://deepwiki.com/nailuj1992/TacoTip-cata-mop-version/3-gearscore-system).
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-04-30 - fix-relic-offhand-gearscore.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-04-30 - fix-relic-offhand-gearscore.md
@@ -1,0 +1,264 @@
+# Fix relic offhand gearscore
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-04-30
+- Thread id: `019de09f-6aa7-7072-8eee-976f1ee94e58`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\04\30\rollout-2026-04-30T20-00-37-019de09f-6aa7-7072-8eee-976f1ee94e58.jsonl`
+- Imported user turns: 11
+- Imported assistant final replies: 11
+- Tool/command events omitted: 180
+
+## Discussion Digest
+
+## User
+
+So I found a bug. its tracking relics/range as off hand and for clases that dont use an offhand its reporting the Gearscore incorrectly for instance attached is my Ret that uses a 2handed weapon no off hand and a relic. If you double the GS provided for just the main hand and relic its my actual gearscore of 6037. Now Aalaska is a Mage and it doesnt even show their weapn offhand etc yet their gearscore and average ilvl is correct.
+
+## Assistant
+
+Fixed. Your read was dead-on: sparse Warmane equipment arrays were shifting relics/ranged/wands into the wrong slot labels, and Lausudoâ€™s relic being labeled `Off Hand` triggered the Titan Grip half-score path.
+
+Changed:
+- [lib/gearscore.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/gearscore.ts:220): Titan Grip half-score now only applies when both main/off-hand items are real weapons.
+- [lib/warmane-armory.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-armory.ts:205): gear slots are repaired from Wowhead `equipLoc`, so relics/wands/ranged become `Ranged`.
+- [lib/gear-layout.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/gear-layout.ts:33) and [PlayerGearSection.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerGearSection.tsx:39): gear display groups by normalized slot name instead of raw array position, so Aalaskaâ€™s staff/wand should land in the weapon row.
+- Added regression tests for the Lausudo-style 2H + relic case and sparse slot layout.
+
+Verification passed:
+- `tests/gearscore-lite.test.ts`
+- `tests/warmane-armory-import.test.ts`
+- `tests/gear-layout.test.ts`
+- gear cache/Wowhead/userscript/tooltip related tests
+- `tsc --noEmit`
+- `next build`
+
+Vault files were updated too. One local note: `git` is not on this shellâ€™s PATH, so I couldnâ€™t run `git diff/status` here.
+
+## User
+
+did you commit?
+
+## Assistant
+
+No, I did not commit.
+
+I made the changes and ran verification, but this PowerShell session couldnâ€™t find `git` on PATH, so nothing was staged or committed.
+
+## User
+
+find it its there
+
+## Assistant
+
+Found it and committed.
+
+Commit: `bd6dd3b fix: repair sparse armory gear slots`
+
+I left these unstaged because they were unrelated local/editor/runtime files:
+- `Pizza Logs HQ/.obsidian/graph.json`
+- `Pizza Logs HQ/.obsidian/workspace.json`
+- `.next-dev.err.log`
+- `.next-dev.log`
+- `tmp-mobile-check/`
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+
+## User
+
+where did you comitt
+
+## Assistant
+
+Committed in:
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+
+On branch `main`, commit:
+
+`bd6dd3b fix: repair sparse armory gear slots`
+
+## User
+
+https://github.com/CRSD-Lau/pizza-logs dont see it my guy
+
+## Assistant
+
+Pushed now. GitHub should show:
+
+`bd6dd3b fix: repair sparse armory gear slots`
+
+Remote was `https://github.com/CRSD-Lau/Pizza-Logs.git`, same repo despite the URL casing difference.
+
+Unrelated local files are still uncommitted only on your machine.
+
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+changed ranged lable to Ranged/Relic maybe since not everyone uses a ranged
+
+## Assistant
+
+Yep, changed it to `Ranged/Relic` and pushed it.
+
+Commit: `c33113b chore: label ranged relic gear slot`
+
+Verified:
+- `tests/warmane-armory-import.test.ts`
+- `tests/gear-layout.test.ts`
+- `tests/gearscore-lite.test.ts`
+- `tsc --noEmit`
+- `next build`
+
+Still left unrelated local files alone: Obsidian workspace/graph, `.next-dev` logs, and `tmp-mobile-check/`.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+can you update whatever needs to be update to ensure i dont have to provide my git repo and that when i want it pushed i want it pushed to git live so railway picks up the deployment
+
+## Assistant
+
+Done and pushed live.
+
+I updated:
+- `AGENTS.md`
+- `CLAUDE.md`
+- `Pizza Logs HQ/00 Inbox/START HERE.md`
+- `Pizza Logs HQ/06 Deployment/Railway Runbook.md`
+- `Pizza Logs HQ/02 Build Log/Latest Handoff.md`
+- `Pizza Logs HQ/03 Current Focus/Now.md`
+
+The instructions now say:
+- canonical remote is `origin -> https://github.com/CRSD-Lau/Pizza-Logs.git`
+- â€œpush/deploy/publish/liveâ€ means commit scoped changes and run `git push origin main`
+- Railway auto-deploys from `origin/main`
+- if `git` is missing from PATH, use `C:\Program Files\Git\cmd\git.exe`
+
+Commit: `e06d168 docs: clarify git deploy target`
+
+Unrelated local files were left alone.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+found another bug where for classes that can equip two mainhand two handers like warrior it doubling their mainhand gs for both equipped when it shouldnt double like it does with say a ret who can only have 1 2handed mainhand
+
+## Assistant
+
+Fixed and pushed.
+
+Root cause was slot normalization: two `INVTYPE_2HWEAPON` items were both being labeled `Main Hand`, so the Titan Grip half-score path never saw an `Off Hand`. Now the first 2H normalizes to `Main Hand`, the second to `Off Hand`, so dual-2H warriors get the half-score behavior while ret 2H + relic still keeps the single doubled 2H score.
+
+Commit: `06fb650 fix: normalize titan grip weapon slots`
+
+Verified:
+- `tests/warmane-armory-import.test.ts`
+- `tests/gearscore-lite.test.ts`
+- `tests/gear-layout.test.ts`
+- `tests/warmane-armory-cache.test.ts`
+- `tests/wowhead-items.test.ts`
+- `tests/wowhead-enrichment-retry.test.ts`
+- `tsc --noEmit`
+- `next build`
+
+Pushed to `origin/main`, so Railway should pick it up.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+the user script for gear doesnt show up now on the warmane site only the guild roster one
+
+## Assistant
+
+Fixed and pushed.
+
+Root cause: both Warmane userscripts rendered their panels at the exact same fixed position: `right:16px; bottom:16px` with the same top-level z-index. The roster panel was covering the gear panel.
+
+Change:
+- Gear panel stays bottom-right.
+- Roster panel now docks above it at `bottom:176px`.
+- Roster userscript bumped to `v1.0.3` so Tampermonkey can update it.
+- Added a regression test so the two userscripts cannot share the same dock position again.
+
+Commit: `50d3d04 fix: stack warmane userscript panels`
+
+Verified:
+- `tests/armory-gear-client-scripts.test.ts`
+- `tests/guild-roster-client-scripts.test.ts`
+- `tsc --noEmit`
+- `next build`
+
+Pushed to `origin/main` for Railway.
+
+After Railway deploys, go to `/admin` and install/update the **Roster Userscript** so Tampermonkey gets `v1.0.3`.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+SS 1 should be a gear sync  via tampermonkey and SS2 should be the guild roster sync for tamper
+
+## Assistant
+
+Youâ€™re right. SS1 should show **Gear Sync** on `/character/...`, and SS2 should show **Roster Sync** on `/guild/...`.
+
+I fixed it properly:
+- Gear userscript now only matches/runs on `armory.warmane.com/character/*`
+- Roster userscript now only matches/runs on `armory.warmane.com/guild/*`
+- Both have runtime guards too, so stale Tampermonkey match metadata exits on the wrong page
+- Both userscripts bumped to `v1.0.4`
+
+Commit: `1844c36 fix: scope warmane userscripts by page`
+
+Verified:
+- `tests/armory-gear-client-scripts.test.ts`
+- `tests/guild-roster-client-scripts.test.ts`
+- `tsc --noEmit`
+- `next build`
+
+Pushed to `origin/main`.
+
+After Railway deploys, update/install both userscripts from `/admin` so Tampermonkey gets `v1.0.4`.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+ok almost at my rate limit. Gonna switch over to Claude. Please Update everything needed so i can have a seemless transition over to that workspace. it also has the pizzalogs folder as a repo and porject work space.
+
+## Assistant
+
+Claude handoff is ready and pushed.
+
+Commit: `ce03f88 docs: prepare claude workspace handoff`
+
+Updated:
+- `CLAUDE.md` with a dedicated transition block
+- `Pizza Logs HQ/02 Build Log/Latest Handoff.md`
+- `Pizza Logs HQ/03 Current Focus/Now.md`
+
+Claude now has explicit notes to:
+- use the existing PizzaLogs repo/workspace
+- read the vault first
+- use `origin -> https://github.com/CRSD-Lau/Pizza-Logs.git`
+- push `main` to `origin` when you ask for live/deploy/publish
+- ignore current local-only noise unless you ask otherwise
+- continue with Warmane userscript v1.0.4 verification
+
+Pushed to `origin/main`.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-01 - plan-roster-sync-api.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-01 - plan-roster-sync-api.md
@@ -1,0 +1,308 @@
+# Plan roster sync API
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-01
+- Thread id: `019de5e3-7358-7012-8cfa-c10042782566`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\01\rollout-2026-05-01T20-33-01-019de5e3-7358-7012-8cfa-c10042782566.jsonl`
+- Imported user turns: 8
+- Imported assistant final replies: 7
+- Tool/command events omitted: 38
+
+## Discussion Digest
+
+## User
+
+So im thinking about updating the API we use to pull the guild roster and the gear sync for each player. Are there better APIs I can use for this task? specifically for wotlk 3.3.5a? or could I do a residential proxy on my railway deployment to bypass the cloudflare security? lets talk about it and plan it out
+
+## User
+
+So im thinking about updating the API we use to pull the guild roster and the gear sync for each player. Are there better APIs I can use for this task? specifically for wotlk 3.3.5a? or could I do a residential proxy on my railway deployment to bypass the cloudflare? lets talk about it and plan it out
+
+## Assistant
+
+Short version: I would **not** build this around a Railway residential proxy to bypass Cloudflare. It will be brittle, likely violates upstream intent/ToS, and I canâ€™t help design an evasion path around Cloudflare. The better direction is: keep Warmane browser-side/import based, make it more reliable, and reduce live scraping with local/static item metadata.
+
+**Whatâ€™s available**
+Warmaneâ€™s undocumented API is still the only useful public-ish source for Warmane-specific roster/gear:
+
+- Character gear: `https://armory.warmane.com/api/character/<name>/<realm>/summary`
+- Guild summary: `https://armory.warmane.com/api/guild/<guild>/<realm>/summary`
+- Guild members: `https://armory.warmane.com/api/guild/<guild>/<realm>/members`
+- Guild HTML page still matters because it can expose things the JSON API may not, like rank/profession context.
+
+Warmane forum users confirm these endpoints exist, but also note the exact problems weâ€™re seeing: no official docs/rate limits, odd JSON shape, errors returned as HTTP 200, missing item slot/ilvl/rank details, etc. Source: [Warmane API feedback](https://forum.warmane.com/showthread.php?t=463405), [How to use Warmane API](https://forum.warmane.com/showthread.php?t=383159).
+
+Blizzardâ€™s official APIs are not a solution for Warmane 3.3.5a. They cover Blizzard realms/data, not private-server characters. Classic API support has historically been limited and separate from retail, and it does not give you Warmane guild/gear state. Sources: [Blizzard Classic API discussion](https://us.forums.blizzard.com/en/blizzard/t/profile-api-for-wow-classic/3522), [Classic Game Data API listing](https://apis.apis.io/apis/battle-net/world-of-warcraft-classic/).
+
+**Best path Iâ€™d plan**
+My recommendation is a 3-source pipeline:
+
+1. **Warmane browser-side userscript remains the live source**
+   Use the adminâ€™s real browser session on Warmane pages to fetch roster and character summaries, then POST normalized payloads into Pizza Logs. This avoids Railway IP blocks without trying to defeat Cloudflare.
+
+2. **Local/static WotLK item metadata**
+   Stop depending on live Wowhead for every item if possible. Build or import a 3.3.5a item metadata table: `itemId`, `name`, `itemLevel`, `inventoryType/equipLoc`, `quality`, `icon`. Sources could be Wowhead tooltip JSON for enrichment, Cavern of Time as fallback, or a TrinityCore/AzerothCore `item_template` export. This makes GearScore deterministic and much faster.
+
+3. **Optional in-game addon/export later**
+   For true WotLK 3.3.5a accuracy, an addon can export guild/raid-visible data to SavedVariables, then Pizza Logs imports that file. Thatâ€™s more work, but it is the cleanest long-term escape hatch from Armory/Cloudflare weirdness.
+
+**The proxy question**
+A residential proxy on Railway would probably â€œwork until it doesnâ€™t,â€ but itâ€™s the wrong foundation. It adds cost, secret handling, ban/challenge risk, and a cat-and-mouse dependency. Iâ€™d only consider a proxy-like route if Warmane explicitly provides/approves an API access method or allowlists an integration.
+
+One key question before we design this: do you want the next iteration optimized for **minimum manual effort** for you as admin, or for **maximum reliability/accuracy** even if it means installing a small addon or doing occasional exports?
+
+## User
+
+i want everything to be automated. i dont want to be fetching gear and guild roster updates manually just for the backend code to fail like its doing now leaving my web app with broke soruces
+
+## Assistant
+
+Yep. Then the target design should be: **Pizza Logs never depends on live Warmane/Wowhead requests during page render**, and sync failures must never destroy or hide the last good data.
+
+Iâ€™d split this into two problems:
+
+**1. Automated Data Collection**
+Best practical option: a **Pizza Logs Sync Agent** that runs outside Railway on a normal residential/home machine or small always-on box. It would run on a schedule, fetch Warmane roster/gear, enrich items, then POST clean snapshots to your Railway app.
+
+I would not use Railway itself for Warmane/Wowhead polling because that is exactly the failing path: datacenter IPs get challenged/blocked. I also canâ€™t help build a residential proxy path to bypass Cloudflare, but a local sync agent using your normal network/browser session is a cleaner, non-cat-and-mouse version of the same practical idea.
+
+**2. Backend Must Become Snapshot-First**
+Right now, live source failure can leave the app feeling broken. The backend should treat external APIs as unreliable imports, not live dependencies.
+
+Rules Iâ€™d add:
+
+- Keep `lastGoodRosterSnapshot`.
+- Keep `lastGoodGearSnapshot` per character.
+- Never overwrite good gear/roster data with failed, empty, partial, or Cloudflare HTML responses.
+- Track source health: `lastAttemptAt`, `lastSuccessAt`, `lastError`, `source`.
+- Show stale data with a small â€œlast syncedâ€ timestamp instead of broken/missing panels.
+- For roster, donâ€™t remove missing players immediately. Require N consecutive successful roster syncs where theyâ€™re absent, or mark them inactive after X days.
+- For gear, update a character only after a complete valid snapshot. Partial item enrichment should merge with previous metadata, not wipe it.
+
+**Approaches**
+My recommendation is **Approach A**.
+
+**A. Local/Residential Sync Agent**
+A small Node/TypeScript worker runs via Windows Task Scheduler, Docker, or a cheap always-on mini PC. It does:
+
+- Every 6-12 hours: sync guild roster.
+- Every 12-24 hours: sync gear for roster members and known logged players.
+- Queue + retry with backoff.
+- POST results to `/api/admin/guild-roster/import` and `/api/admin/armory-gear/import`.
+- Backend stores only validated snapshots.
+
+This gives you near-full automation without depending on Railwayâ€™s blocked IPs.
+
+**B. In-Game Addon + Companion App**
+Most robust long-term, no Warmane Armory needed for some data. Addon captures guild roster and player gear into SavedVariables; companion app uploads it automatically. Downside: full guild gear requires guildies to run it, or an officer to inspect people while online.
+
+**C. Server Cron Only**
+Cleanest operationally, but not realistic if Railway IPs are blocked. We can still keep server cron for retrying internal queues, but not as the primary Warmane fetcher.
+
+**What Iâ€™d Build First**
+Phase 1: harden the backend so broken sources canâ€™t break pages.
+
+Phase 2: build a local `pizza-logs-sync-agent` that automates current roster/gear import.
+
+Phase 3: add source-health UI on `/admin`: last successful roster sync, gear queue count, failed characters, stale characters, next scheduled run.
+
+Phase 4: optionally replace Wowhead live enrichment with a local WotLK item metadata table so item level/slot/icon data becomes deterministic.
+
+The important shift is: **Railway hosts the app; a sync agent feeds it trusted snapshots.** Railway should not be responsible for fighting Warmane/Wowhead availability.
+
+## User
+
+the data i need is on warmanes armory so lets build to pull from there except in an acurate reliable way. my dekstop and laptop are usually on
+
+## Assistant
+
+Yes. Iâ€™d build this as a **local Warmane sync agent** plus a hardened snapshot backend.
+
+**Recommended Design**
+Run a small Pizza Logs sync process on your desktop and optionally laptop. It pulls from Warmane Armory on a schedule, validates the data, enriches item metadata, then posts clean snapshots to the Railway app.
+
+Flow:
+
+```text
+Desktop/Laptop Sync Agent
+  -> Warmane guild API / guild page
+  -> Warmane character API for each roster player
+  -> item metadata enrichment
+  -> Pizza Logs import APIs
+  -> DB stores validated snapshots only
+```
+
+Railway becomes the receiver/database/UI, not the thing trying to fetch Warmane live.
+
+**Why This Fits**
+Your desktop/laptop are usually on, and they use normal residential connections. That avoids the Railway IP problem without turning the deployed app into a Cloudflare workaround machine.
+
+For reliability, we make the agent conservative:
+
+- Fetch roster every 6-12 hours.
+- Fetch gear for stale/missing roster members every 12-24 hours.
+- Retry failed characters with backoff.
+- Never post empty/invalid data as a â€œsuccess.â€
+- Keep a local queue file so it can resume after sleep/reboot.
+- Use one active sync source at a time so desktop and laptop donâ€™t fight each other.
+
+**Backend Changes**
+The backend should stop behaving like live source failure equals missing data.
+
+Iâ€™d add:
+
+- `lastSuccessAt`, `lastAttemptAt`, `lastError`, `sourceAgent`
+- snapshot validation before write
+- no overwriting good gear with partial/empty gear
+- no immediate roster deletion when a player disappears
+- stale-but-valid display states
+- admin sync health panel
+
+So even if Warmane is down, Cloudflare challenges, your PC sleeps, or a player API call fails, the public app still shows the last known good roster/gear.
+
+**Accuracy**
+For gear, the agent should pull the Warmane character summary as the authority for equipped items. For slot/item level/icon data, we should prefer a local WotLK item metadata table if possible, then fall back to Wowhead/Cavern of Time enrichment. That makes GearScore far more deterministic.
+
+**Implementation Choice**
+Iâ€™d build the first version as a repo-local Node/TypeScript CLI:
+
+```bash
+npm run sync:warmane
+```
+
+Then we add a Windows Task Scheduler setup script so your desktop/laptop can run it automatically.
+
+One important design question before we write the spec: should the sync agent run on **both desktop and laptop with a backend lock**, or do you want **desktop primary, laptop backup only**?
+
+## User
+
+im working on my laptop now. lets do laptop
+
+## Assistant
+
+Perfect. Laptop-primary is the cleanest first version.
+
+**Design**
+Weâ€™ll build a repo-local **Warmane Sync Agent** meant to run from your laptop. It will pull Warmane Armory data directly from your laptop network, validate it, and POST snapshots into the live Pizza Logs app.
+
+Initial command:
+
+```bash
+npm run sync:warmane
+```
+
+Later automation:
+
+```text
+Windows Task Scheduler
+  -> runs every 6 or 12 hours
+  -> starts from PizzaLogs repo
+  -> calls the sync command
+  -> writes logs locally
+```
+
+**Agent Behavior**
+The agent should:
+
+- fetch `PizzaWarriors` roster from Warmane guild page/API
+- import roster to Pizza Logs
+- ask Pizza Logs for missing/stale gear queue
+- fetch Warmane character summaries for those players
+- enrich gear metadata
+- import each valid gear snapshot
+- retry failures gently
+- resume safely if your laptop sleeps or disconnects
+
+**Backend Safety**
+Before relying on automation, Iâ€™d harden the import path so bad source data cannot damage the app:
+
+- reject Cloudflare/HTML/error responses as invalid
+- reject empty roster/gear snapshots
+- never overwrite good gear with partial gear
+- keep last good data visible
+- record sync status/errors for admin visibility
+
+**First Milestone**
+Iâ€™d make v1 laptop-only, no desktop/laptop coordination yet. Once that works, we can add â€œdesktop as backupâ€ with a backend sync lock.
+
+If this design looks right, Iâ€™ll write the design spec into the repo next, then we can turn it into an implementation plan and build it.
+
+## User
+
+lets do it
+
+## Assistant
+
+Done. I wrote and committed the laptop-primary Warmane sync agent design.
+
+Spec: [2026-05-01-warmane-sync-agent-design.md](<C:/Users/neil_/OneDrive/Desktop/PizzaLogs/docs/superpowers/specs/2026-05-01-warmane-sync-agent-design.md>)
+Commit: `613744b docs: design Warmane sync agent`
+
+I also updated the vault handoff, current focus, and known blockers so the next session has the right context. I left the unrelated untracked `tmp-mobile-check/` folder alone.
+
+Please review the spec and tell me if you want any changes before I write the implementation plan.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+
+## User
+
+i have about 14% left in my weekly plan. should i take this project on in Claude? this project is over there as well
+
+## Assistant
+
+Honestly: yes, Claude is fine for this project, but Iâ€™d be careful about **where the source of truth lives**.
+
+You have only ~14% left here, so Iâ€™d save this session for high-leverage things: architecture decisions, reviewing Claudeâ€™s patches, debugging a specific failure, or deployment help. The Warmane sync agent build is a real multi-step implementation, so it may chew through that 14% fast.
+
+If you move it to Claude, do this first:
+
+1. Make sure Claude has the latest repo state, including commit `613744b docs: design Warmane sync agent`.
+2. Tell Claude to read:
+   - `AGENTS.md`
+   - `Pizza Logs HQ/00 Inbox/START HERE.md`
+   - `Pizza Logs HQ/02 Build Log/Latest Handoff.md`
+   - `Pizza Logs HQ/03 Current Focus/Now.md`
+   - `docs/superpowers/specs/2026-05-01-warmane-sync-agent-design.md`
+3. Ask it to write an implementation plan before coding.
+
+You can paste this to Claude:
+
+```text
+We are building the laptop-primary Warmane sync agent for Pizza Logs.
+
+Before coding, read AGENTS.md and the required vault files:
+- Pizza Logs HQ/00 Inbox/START HERE.md
+- Pizza Logs HQ/02 Build Log/Latest Handoff.md
+- Pizza Logs HQ/03 Current Focus/Now.md
+
+Then read:
+- docs/superpowers/specs/2026-05-01-warmane-sync-agent-design.md
+
+Write an implementation plan first. The goal is an automated local laptop sync agent that fetches Warmane guild roster and gear data, validates snapshots, posts them to the hosted Pizza Logs app, and hardens the backend so bad/empty source data never overwrites last known good data.
+```
+
+My take: let Claude do the bigger implementation if you have more room there. Keep this Codex thread as the â€œcontinuity brainâ€ and review/debug partner.
+
+## User
+
+ok update my claude files with this project. gonna move to my dekstop as well
+
+## Assistant
+
+Updated and committed the Claude handoff.
+
+Changed:
+- [CLAUDE.md](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/CLAUDE.md) now tells Claude about the laptop-primary Warmane sync agent, the spec to read, the no Railway proxy boundary, and v1 priorities.
+- Updated vault handoff/current focus so the project state matches.
+
+Commit: `4bbef54 docs: update Claude handoff for sync agent`
+
+I did not push to `origin`, so a separate desktop checkout will need this commit via push/pull. The only untracked item left is still `tmp-mobile-check/`, untouched.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - add-character-headshots-2.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - add-character-headshots-2.md
@@ -1,0 +1,657 @@
+# Add character headshots
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019df03c-1a80-79c2-b476-f0ab4300d4ad`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T20-46-04-019df03c-1a80-79c2-b476-f0ab4300d4ad.jsonl`
+- Imported user turns: 20
+- Imported assistant final replies: 14
+- Tool/command events omitted: 389
+
+## Discussion Digest
+
+## User
+
+[@superpowers](plugin://superpowers@openai-curated)
+
+You are working in my â€œPizza Logsâ€ project.
+
+Goal:
+Replace the initials box in the character header/card â€” currently showing something like â€œLIâ€ â€” with the characterâ€™s actual WoW headshot / portrait image when available.
+
+Context:
+The UI currently displays a character summary like:
+
+- Name: Lichkingspet
+- Race/class: Human Death Knight
+- Level: 80
+- Realm/server: Lordaeron
+- Guild: PizzaWarriors
+- Current icon square: initials fallback, e.g. â€œLIâ€
+
+I want you to investigate and implement the best practical way to show the character headshot.
+
+Possible data sources:
+1. AzerothCore database
+2. Warmane Armory, possibly through Tampermonkey if direct fetching/scraping is blocked by CORS or not feasible from the app
+
+Tasks:
+
+1. Inspect the codebase
+   - Find the component/template responsible for rendering the character header/card.
+   - Find where the initials square is generated.
+   - Identify the character data object shape currently available to that component.
+   - Determine whether we already have character name, realm, faction, race, class, gender, and/or GUID available.
+
+2. Investigate AzerothCore DB feasibility
+   - Check whether the AzerothCore characters/world DB contains enough data to derive or fetch a character headshot.
+   - Look specifically at tables such as:
+     - characters.characters
+     - characters.character_inventory
+     - characters.item_instance
+     - world.item_template
+     - any race/class/gender/display-related tables available in this project
+   - Determine whether the DB stores only character metadata/equipment, or whether it exposes an actual portrait/headshot/image URL.
+   - If the DB does not contain a ready-to-use image, explain what would be required to generate one, such as DBC data, model rendering, display IDs, or an external renderer.
+   - Do not assume AzerothCore has a portrait URL unless verified in the schema or code.
+
+3. Investigate Warmane Armory feasibility
+   - Determine whether Warmane Armory exposes a character portrait/headshot image on the public character profile page.
+   - Find the character armory URL pattern for realm + character name.
+   - Check whether the portrait/headshot image is present as:
+     - an `<img>` tag,
+     - CSS background image,
+     - Open Graph image,
+     - canvas/rendered asset,
+     - or some API/network response.
+   - If direct app fetching is blocked by CORS, design a Tampermonkey-based approach using `GM_xmlhttpRequest`.
+   - The Tampermonkey option should either:
+     - inject portraits directly into Pizza Logs pages by matching character names/realms, or
+     - scrape Warmane Armory portrait URLs and store/cache them for Pizza Logs to use.
+
+4. Recommend the best implementation path
+   Compare:
+   - AzerothCore DB route
+   - Warmane Armory route
+   - Tampermonkey route
+   - simple fallback to initials
+
+   Consider:
+   - reliability
+   - implementation effort
+   - CORS limitations
+   - cacheability
+   - whether portraits update when gear changes
+   - whether this can work for all characters or only Warmane characters
+
+5. Implement the chosen solution if feasible
+   Requirements:
+   - Preserve the initials fallback when no portrait is available.
+   - Do not break the current character card layout.
+   - Add a clean `avatarUrl` / `portraitUrl` field or equivalent rather than hard-coding image logic inside the visual component.
+   - Add error handling for broken image URLs.
+   - Cache portrait lookups where appropriate.
+   - Avoid excessive requests to Warmane Armory.
+   - Make the implementation easy to disable or configure.
+
+6. If Tampermonkey is the best route, create a userscript
+   The userscript should:
+   - Run on the Pizza Logs domain/local URL.
+   - Find character cards that still show initials.
+   - Extract character name and realm from the DOM or embedded data.
+   - Query Warmane Armory using `GM_xmlhttpRequest`.
+   - Parse the portrait/headshot URL from the returned HTML.
+   - Replace the initials square with an `<img>` element.
+   - Cache results in `localStorage` or Tampermonkey storage.
+   - Fall back to initials when no portrait is found.
+   - Include comments showing how to update the Pizza Logs URL match pattern.
+
+7. Deliverables
+   Provide:
+   - A concise explanation of what you found.
+   - The recommended approach.
+   - Code changes, if possible.
+   - A Tampermonkey userscript if needed.
+   - Any new config keys or environment variables.
+   - Notes on limitations.
+
+Important:
+- Do not fabricate Warmane endpoints. Inspect the actual page/network/HTML structure where possible.
+- Do not assume AzerothCore stores rendered character portraits.
+- Prefer a robust fallback-based implementation:
+  portrait image if available â†’ class/race icon if available â†’ initials.
+- Keep the visual design consistent with the current dark UI.
+
+## User
+
+did you change anything?
+
+## User
+
+was the wrong prompt
+
+## Assistant
+
+No, I didnâ€™t change any files. `git status --short --branch` is clean:
+
+```text
+## codex/pizza-logs-modernization
+```
+
+I only read the required project docs, inspected existing portrait-related files, ran a few tests, and checked Warmane fetch behavior. No commits, staging, patches, or file writes.
+
+## User
+
+[@superpowers](plugin://superpowers@openai-curated)
+
+You are working in my Pizza Logs project.
+
+New feature:
+Add a global player search bar in the site header.
+
+Use Superpowers and any other relevant Codex skills/plugins/subagents you think are useful. Inspect the full codebase before changing anything.
+
+Goal:
+Users should be able to search for players directly from the header and navigate to the matching player profile page.
+
+Requirements:
+
+1. Codebase discovery
+   - Find the main layout/header/navigation component.
+   - Find the player profile route pattern, likely `/players/[name]` or equivalent.
+   - Find the player data source/API currently used by the Players page.
+   - Identify whether players are loaded from uploads, cached roster data, Warmane roster sync, or database tables.
+
+2. Search bar UI
+   - Add a compact search input to the header.
+   - Must fit the current Pizza Logs dark/fantasy UI.
+   - Placeholder: `Search players...`
+   - Should work on desktop and mobile.
+   - Should not break existing header layout/navigation.
+   - Include keyboard support.
+
+3. Search behavior
+   - User types a player name.
+   - Show matching player results in a dropdown/autocomplete.
+   - Match case-insensitively.
+   - Support partial matches.
+   - Prefer exact match at the top.
+   - Show useful metadata if available:
+     - player name
+     - class
+     - race
+     - level
+     - guild
+     - realm
+   - On selecting a player, navigate to that playerâ€™s profile page.
+   - Pressing Enter should navigate to the best match.
+   - Escape should close the dropdown.
+   - Clicking outside should close the dropdown.
+
+4. Backend/API
+   - Reuse an existing players endpoint if available.
+   - If no good endpoint exists, add a lightweight endpoint such as:
+     - `GET /api/players/search?q=<query>`
+   - Limit returned results, for example 10â€“20.
+   - Avoid loading every combat log record just to search players.
+   - Use indexed/cached player/profile tables where possible.
+   - Sanitize input.
+   - Handle empty queries.
+   - Return stable JSON.
+
+5. Performance
+   - Debounce search input.
+   - Avoid excessive API calls.
+   - Cache recent query results client-side if simple to do.
+   - Do not block page rendering.
+   - Ensure this works against production data volume.
+
+6. Routing
+   - Confirm the correct player profile URL format before implementing.
+   - If player names need URL encoding, handle that safely.
+   - If realm is part of the route or lookup, account for that.
+   - Prevent broken navigation for ambiguous duplicate names where possible.
+
+7. Fallback states
+   - Loading state while searching.
+   - Empty state: `No players found`
+   - Error state that does not break the header.
+   - Clear button or easy way to reset input.
+
+8. Testing
+   - Add or update tests where the project supports them.
+   - Test:
+     - partial match
+     - exact match priority
+     - no results
+     - keyboard Enter navigation
+     - Escape close
+     - click result navigation
+     - mobile layout
+   - Run lint/typecheck/build/test commands used by the project.
+   - Fix any regressions.
+
+9. Documentation
+   - Update relevant docs/README if the project tracks user-facing features.
+   - Add a short note explaining the player search source and endpoint.
+
+Implementation preference:
+- Keep this feature clean and maintainable.
+- Do not overengineer it.
+- Prefer a reusable `PlayerSearch` component placed inside the header.
+- Keep visual styling consistent with the rest of Pizza Logs.
+- Do not remove existing navigation behavior.
+
+Deliverables:
+- Summary of files changed.
+- Explanation of how the search works.
+- Any new API endpoint details.
+- Test/build results.
+- Limitations or follow-up improvements.
+
+## Assistant
+
+Implemented global player search on `codex/pizza-logs-modernization`.
+
+Changed:
+- [lib/player-search.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-search.ts): search/ranking/keyboard helpers.
+- [app/api/players/search/route.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/api/players/search/route.ts): `GET /api/players/search?q=<query>`.
+- [components/players/PlayerSearch.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerSearch.tsx): debounced autocomplete UI.
+- [components/layout/Nav.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/layout/Nav.tsx): header/mobile nav integration.
+- Docs/vault updated: README, Data Model, Feature Status, Latest Handoff, Now.
+- Added tests: `player-search`, `player-search-route`, `player-search-ui-source`.
+
+How it works:
+- Searches combat-log `players` plus scoped PizzaWarriors/Lordaeron `guild_roster_members`.
+- Does not scan uploads, participants, combat-log rows, full roster gear, or gear cache blobs.
+- Merges duplicates by name+realm, fills roster metadata, ranks exact matches first, supports partial case-insensitive matches.
+- Enter navigates to best/active result, Escape closes, click outside closes, clear button resets.
+
+Validation:
+- New focused tests passed.
+- Full TS test sweep passed: 21 tests.
+- `tsc --noEmit` passed.
+- Full ESLint passed.
+- `git diff --check` passed.
+- Temp-copy production build passed. The in-place OneDrive build still hits the known `.next` `readlink` issue; temp build emitted the expected node_modules junction trace warning.
+
+Local dev server is running at [http://127.0.0.1:3000/admin/login](http://127.0.0.1:3000/admin/login). Search results need the local database/Postgres available; without it, the UI renders but the API returns a DB-backed 500 locally.
+
+## User
+
+lets keep going
+
+## Assistant
+
+Kept going and added one small cleanup: [PlayerSearch.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerSearch.tsx) now uses `useId()` so desktop and mobile search instances donâ€™t share a hard-coded results-list id.
+
+I also restarted the dev server with logs. Itâ€™s running at [http://127.0.0.1:3000/admin/login](http://127.0.0.1:3000/admin/login), and that page renders the header search. Local `/api/players/search?q=lich` returns stable error JSON because local Postgres isnâ€™t available:
+
+```json
+{"ok":false,"query":"lich","results":[],"error":"Player search failed"}
+```
+
+Fresh checks after that cleanup:
+- `tests/player-search.test.ts` passed
+- `tests/player-search-route.test.ts` passed
+- `tsc --noEmit` passed
+- `git diff --check` passed
+
+No files were staged or committed.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/admin/login
+
+## My request for Codex:
+im confused what are you building i just want all pages to have a search function bar in the headers
+
+## Assistant
+
+Youâ€™re right. The intended feature is just: every pageâ€™s shared header has a player search bar.
+
+I adjusted it so itâ€™s visible in the header on all screen sizes:
+- Desktop: search bar sits in the main header row.
+- Mobile/tablet: search bar is always visible under the logo/menu row.
+- Hamburger now only controls nav links, not access to search.
+
+The page at `http://127.0.0.1:3000/admin/login` now renders `Search players...` twice in HTML because both desktop and mobile variants exist, with CSS showing the right one for the viewport. Refresh the in-app browser and you should see the search bar in the header.
+
+Fresh checks passed:
+- `tests/player-search-ui-source.test.ts`
+- `tests/player-search.test.ts`
+- `tsc --noEmit`
+- focused ESLint on `Nav` and `PlayerSearch`
+- `git diff --check`
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/admin/login
+
+## My request for Codex:
+
+## Assistant
+
+Youâ€™re right: the work is the global header player search.
+
+I added it to the shared header/nav, so it appears across the app when the page renders:
+- [Nav.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/layout/Nav.tsx>)
+- [PlayerSearch.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerSearch.tsx>)
+- [search route](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/api/players/search/route.ts>)
+- [search logic](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-search.ts>)
+
+The screenshot was a separate local issue: Postgres is not running at `localhost:5432`, so `/admin` was crashing before the header could show. I fixed `/admin` to fail gracefully with a â€œDatabase unavailableâ€ warning, and confirmed `http://127.0.0.1:3000/admin` now returns `200` and includes `Search players`.
+
+Search behavior:
+- debounced `Search players...` input in the header
+- dropdown autocomplete
+- partial/exact matching
+- Enter navigates to best match
+- Escape closes
+- click outside closes
+- results come from `players` plus PizzaWarriors/Lordaeron `guild_roster_members`
+- navigation goes to `/players/<name>`
+
+Verification passed:
+- `tests/player-search.test.ts`
+- `tests/player-search-route.test.ts`
+- `tests/player-search-ui-source.test.ts`
+- `tests/admin-page-db-unavailable.test.ts`
+- `tsc --noEmit`
+- full ESLint
+- `git diff --check`
+- clean temp-copy `next build`
+
+Local limitation: real search results need the database running. With DB offline, the search UI stays up but the API returns the controlled error state.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+the other pages are broken though... test the whole test
+
+## Assistant
+
+You were right. The other pages were breaking because local Postgres is offline, and those pages were throwing during server render before the shared header/search could show.
+
+I fixed the main public/admin pages to handle DB connection failure gracefully:
+- `/`
+- `/players`
+- `/raids`
+- `/leaderboards`
+- `/bosses`
+- `/guild-roster`
+- `/weekly`
+- `/admin`
+- `/admin/login`
+
+They now render the header search and show a dark `Database unavailable` warning instead of the Next error overlay. I also hid misleading â€œNo data yetâ€ states while the DB is down.
+
+Added:
+- [DatabaseUnavailable.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/ui/DatabaseUnavailable.tsx>)
+- [database-errors.ts](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/database-errors.ts>)
+- [database-errors.test.ts](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/database-errors.test.ts>)
+
+Verified:
+- Local smoke test: all listed pages return `200` and include `Search players`; `/uploads` returns expected `307` redirect.
+- Full TS test sweep: `23` test files passed.
+- `tsc --noEmit`: passed.
+- Full ESLint: passed.
+- `git diff --check`: passed.
+- Temp-copy `next build`: passed. It still prints the known Windows junction warning for `node_modules`, but exits `0`.
+
+Direct API endpoints still require the DB; the pages no longer collapse when DB is offline.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+All the pages work but still cant reach db
+
+## Assistant
+
+The app is still saying â€œcanâ€™t reach DBâ€ because there is no database server running locally.
+
+What I verified:
+- `.env.local` points to `localhost:5432`, database `pizzalogs`, user `pizzalogs`.
+- `localhost:5432` is closed.
+- No Postgres process/service is running.
+- `docker` is not installed/on PATH, so `docker compose up postgres` cannot run right now.
+
+So the pages are fixed, but theyâ€™re showing fallback UI because the actual DB runtime is missing.
+
+To get real data locally, use one of these:
+
+```powershell
+docker compose up -d postgres
+npm run db:push
+npm run db:seed
+npm run db:import-items
+```
+
+But that needs Docker Desktop installed first.
+
+Alternative: install/start local PostgreSQL and create a `pizzalogs` DB/user matching `.env.local`, then run the same Prisma seed commands.
+
+The other option is to point `.env.local` at the Railway Postgres URL, but that means your local app will read/write production data, so I would not do that casually.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+do the local db setup for me
+
+## Assistant
+
+Local Postgres is not installed. I found `PostgreSQL.PostgreSQL.16` available through `winget`, which matches the repoâ€™s Docker config.
+
+Please confirm you want me to install PostgreSQL 16 via `winget`. This will install new software, create a local Postgres service on your machine, and use port `5432` so Pizza Logs can connect to `postgresql://[REDACTED]
+
+Command Iâ€™m ready to run after confirmation:
+
+```powershell
+winget install --id PostgreSQL.PostgreSQL.16 --source winget --accept-package-agreements --accept-source-agreements
+```
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+yep set it all up please
+
+## Assistant
+
+Local DB is set up now.
+
+What I did:
+- Installed PostgreSQL 16 via `winget`.
+- Started service `postgresql-x64-16`; it is `Running` and `Automatic`.
+- Created local `pizzalogs` role/database matching `.env.local`.
+- Ran Prisma generate + `db push`.
+- Seeded bosses/realms.
+- Imported AzerothCore item metadata.
+
+Verified:
+- `localhost:5432` is reachable.
+- DB counts: `53` bosses, `4` realms, `38,610` item rows, `0` players.
+- Restarted Next dev server on `http://127.0.0.1:3000`.
+- Smoke test returned HTTP `200` with no DB warning for pages and APIs including `/players`, `/bosses`, `/admin`, `/api/players/search?q=lich`, `/api/bosses`, `/api/uploads`.
+
+The DB is live, but it is fresh. Player search returns no results until you upload a combat log or import/sync Warmane roster data.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+can you not just pull from the live db into it
+
+## Assistant
+
+Yes, but I donâ€™t currently have access to the live DB connection.
+
+I checked:
+- No `railway` CLI installed.
+- No Railway token/env IDs in this shell.
+- No production `DATABASE_URL` in local env files.
+- Local `.env.local` only points to the new local DB.
+
+To pull live into local, I need one of these:
+1. The Railway production Postgres `DATABASE_URL`, or
+2. Railway CLI installed/logged in, with project access.
+
+Once I have that, the flow is straightforward:
+- `pg_dump` live DB
+- restore into local `pizzalogs`
+- run a quick Prisma/API smoke test
+
+Important: this copies production data onto your machine and will replace or merge local DB data depending how we do it. Since this local DB is fresh, replace is probably fine.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+postgresql://[REDACTED]
+
+## Assistant
+
+That URL wonâ€™t work from your laptop because `postgres.railway.internal` is private Railway DNS. I checked it: name resolution fails locally.
+
+I need the public Railway Postgres URL instead. It usually has a non-internal host and often a proxy port, for example a host like `*.proxy.rlwy.net` rather than `postgres.railway.internal`.
+
+Once you give me the public/proxy `DATABASE_URL`, I can run the dump/restore into local using the Postgres tools that are now installed:
+- `pg_dump.exe`
+- `pg_restore.exe`
+- `psql.exe`
+
+Do not paste it if you are unsure it is the public/proxy URL; the key difference is: it must not contain `.internal`.
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+postgresql://[REDACTED]
+
+## Assistant
+
+I exported the live Railway data successfully into local temp CSV files.
+
+Live export counts:
+- `players`: 68
+- `guild_roster_members`: 137
+- `uploads`: 2
+- `encounters`: 36
+- `participants`: 572
+- `armory_gear_cache`: 186
+- `wow_items`: 38,610
+- plus bosses/guilds/realms/milestones
+
+Next step will replace the local `pizzalogs` DB contents by truncating local tables, then importing this live snapshot. That deletes the current local seeded data, but it is just the fresh local setup we created.
+
+Please confirm: should I overwrite the local database with this live snapshot?
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+yes
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+you have m railway db you it to import over the empty local db please
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+try again
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3000/players
+
+## My request for Codex:
+Ok just commit and push to git. i think its close enough to test live
+
+## User
+
+remove teh public url then push what you had before
+
+## Assistant
+
+Pushed to `origin/main`.
+
+I removed the public Railway URL from the work product by verifying it was not present in the staged repo content. Staged secret scan found no public Railway host, password, internal Railway URL, Railway token, or production-style `DATABASE_URL`.
+
+Commit:
+`4fa13a6 Add global player search`
+
+Verification before push:
+- Focused search/admin/db tests passed.
+- Full TypeScript test sweep passed: `23` test files.
+- `tsc --noEmit` passed.
+- Full ESLint passed.
+- `git diff --check` passed.
+- Temp-copy `next build` passed with the known Windows junction warning.
+- Live app root returned HTTP `200` after push.
+
+`main` is checked out in another local worktree, so I pushed this branch HEAD directly to `origin/main` as a fast-forward.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+push
+
+## Assistant
+
+Pushed.
+
+Both are now at `4fa13a6`:
+- `origin/main`
+- `origin/codex/pizza-logs-modernization`
+
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/pizza-logs-modernization"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - add-character-headshots.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - add-character-headshots.md
@@ -1,0 +1,383 @@
+# Add character headshots
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019defb7-6b06-73f0-8d13-611b9f6339e0`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T18-21-08-019defb7-6b06-73f0-8d13-611b9f6339e0.jsonl`
+- Imported user turns: 11
+- Imported assistant final replies: 9
+- Tool/command events omitted: 426
+
+## Discussion Digest
+
+## User
+
+You are working in my â€œPizza Logsâ€ project.
+
+Goal:
+Replace the initials box in the character header/card â€” currently showing something like â€œLIâ€ â€” with the characterâ€™s actual WoW headshot / portrait image when available.
+
+Context:
+The UI currently displays a character summary like:
+
+- Name: Lichkingspet
+- Race/class: Human Death Knight
+- Level: 80
+- Realm/server: Lordaeron
+- Guild: PizzaWarriors
+- Current icon square: initials fallback, e.g. â€œLIâ€
+
+I want you to investigate and implement the best practical way to show the character headshot.
+
+Possible data sources:
+1. AzerothCore database
+2. Warmane Armory, possibly through Tampermonkey if direct fetching/scraping is blocked by CORS or not feasible from the app
+
+Tasks:
+
+1. Inspect the codebase
+   - Find the component/template responsible for rendering the character header/card.
+   - Find where the initials square is generated.
+   - Identify the character data object shape currently available to that component.
+   - Determine whether we already have character name, realm, faction, race, class, gender, and/or GUID available.
+
+2. Investigate AzerothCore DB feasibility
+   - Check whether the AzerothCore characters/world DB contains enough data to derive or fetch a character headshot.
+   - Look specifically at tables such as:
+     - characters.characters
+     - characters.character_inventory
+     - characters.item_instance
+     - world.item_template
+     - any race/class/gender/display-related tables available in this project
+   - Determine whether the DB stores only character metadata/equipment, or whether it exposes an actual portrait/headshot/image URL.
+   - If the DB does not contain a ready-to-use image, explain what would be required to generate one, such as DBC data, model rendering, display IDs, or an external renderer.
+   - Do not assume AzerothCore has a portrait URL unless verified in the schema or code.
+
+3. Investigate Warmane Armory feasibility
+   - Determine whether Warmane Armory exposes a character portrait/headshot image on the public character profile page.
+   - Find the character armory URL pattern for realm + character name.
+   - Check whether the portrait/headshot image is present as:
+     - an `<img>` tag,
+     - CSS background image,
+     - Open Graph image,
+     - canvas/rendered asset,
+     - or some API/network response.
+   - If direct app fetching is blocked by CORS, design a Tampermonkey-based approach using `GM_xmlhttpRequest`.
+   - The Tampermonkey option should either:
+     - inject portraits directly into Pizza Logs pages by matching character names/realms, or
+     - scrape Warmane Armory portrait URLs and store/cache them for Pizza Logs to use.
+
+4. Recommend the best implementation path
+   Compare:
+   - AzerothCore DB route
+   - Warmane Armory route
+   - Tampermonkey route
+   - simple fallback to initials
+
+   Consider:
+   - reliability
+   - implementation effort
+   - CORS limitations
+   - cacheability
+   - whether portraits update when gear changes
+   - whether this can work for all characters or only Warmane characters
+
+5. Implement the chosen solution if feasible
+   Requirements:
+   - Preserve the initials fallback when no portrait is available.
+   - Do not break the current character card layout.
+   - Add a clean `avatarUrl` / `portraitUrl` field or equivalent rather than hard-coding image logic inside the visual component.
+   - Add error handling for broken image URLs.
+   - Cache portrait lookups where appropriate.
+   - Avoid excessive requests to Warmane Armory.
+   - Make the implementation easy to disable or configure.
+
+6. If Tampermonkey is the best route, create a userscript
+   The userscript should:
+   - Run on the Pizza Logs domain/local URL.
+   - Find character cards that still show initials.
+   - Extract character name and realm from the DOM or embedded data.
+   - Query Warmane Armory using `GM_xmlhttpRequest`.
+   - Parse the portrait/headshot URL from the returned HTML.
+   - Replace the initials square with an `<img>` element.
+   - Cache results in `localStorage` or Tampermonkey storage.
+   - Fall back to initials when no portrait is found.
+   - Include comments showing how to update the Pizza Logs URL match pattern.
+
+7. Deliverables
+   Provide:
+   - A concise explanation of what you found.
+   - The recommended approach.
+   - Code changes, if possible.
+   - A Tampermonkey userscript if needed.
+   - Any new config keys or environment variables.
+   - Notes on limitations.
+
+Important:
+- Do not fabricate Warmane endpoints. Inspect the actual page/network/HTML structure where possible.
+- Do not assume AzerothCore stores rendered character portraits.
+- Prefer a robust fallback-based implementation:
+  portrait image if available â†’ class/race icon if available â†’ initials.
+- Keep the visual design consistent with the current dark UI.
+
+Bias toward a Tampermonkey proof of concept first. I want the fastest working version that replaces the initials box with the Warmane Armory portrait on my existing Pizza Lo
+
+[Truncated for vault import.]
+
+## Assistant
+
+Implemented the Tampermonkey-first proof of concept and the app-side cleanup.
+
+What changed:
+- Added reusable avatar rendering in [PlayerAvatar.tsx](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/players/PlayerAvatar.tsx:26) with `portraitUrl`, class-icon fallback, initials fallback, and broken-image handling.
+- Updated the player profile shape to include `portraitUrl` in [player-profile.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-profile.ts:26).
+- Replaced the initials boxes on `/players/[playerName]` and `/players` with `PlayerAvatar`.
+- Added Warmane portrait helpers in [warmane-portrait.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-portrait.ts:27).
+- Added a public Tampermonkey userscript route:
+  - `/api/player-portraits/userscript.user.js`
+  - source: [player-portrait-client-scripts.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-portrait-client-scripts.ts:16)
+
+Findings:
+- AzerothCore is not a practical portrait source. Its docs show character metadata/customization/equipment fields, not rendered portrait URLs: [characters](https://www.azerothcore.org/wiki/characters), [character_inventory](https://www.azerothcore.org/wiki/character_inventory), [item_instance](https://www.azerothcore.org/wiki/item_instance), [ChrRaces.dbc](https://www.azerothcore.org/wiki/chrraces).
+- Warmane URL pattern is `https://armory.warmane.com/character/<name>/<realm>/summary`; public pages such as [this Warmane profile](https://armory.warmane.com/character/Section/Lordaeron/profile) confirm the pattern and profile metadata.
+- Direct local server/headless requests to Warmane hit Cloudflare 403/challenge, so backend live-fetch is unreliable.
+- I did not verify a static Warmane headshot URL in the extracted HTML. The userscript therefore tries static `<img>`, CSS background, meta image, and script-data patterns, then falls back to class icon/initials.
+
+Verification:
+- Passed: `tsc --noEmit`
+- Passed: `eslint . --max-warnings=0`
+- Passed: `tests/warmane-portrait.test.ts`
+- Passed: `tests/player-portrait-client-scripts.test.ts`
+- Passed: `tests/player-profile.test.ts`
+- Passed: `tests/armory-gear-client-scripts.test.ts`
+- `next build` passed once before the final legacy-DOM userscript fallback. A later rebuild was blocked by OneDrive `.next` reparse/cloud-file state; I did not delete generated `.next` without confirmation.
+
+No new environment variables. Disable the portrait userscript with:
+`localStorage.pizzaLogsWarmanePortraitsDisabled = "1"`
+
+## User
+
+we commit?
+
+## User
+
+did you push to git?
+
+## Assistant
+
+No, not committed and not pushed.
+
+Current branch: `codex/pizza-logs-modernization`
+
+There are uncommitted changes for the portrait POC, including app code, tests, and vault handoff docs. I stopped before staging/committing because the final `next build` rerun hit the local OneDrive `.next` reparse-file issue after the earlier successful build.
+
+## User
+
+so lets get it to git so i can deploy and test live.
+
+## Assistant
+
+Yes. Committed and pushed to `origin/main`.
+
+Commit: `bd663f7 feat: add Warmane portrait userscript`
+
+Live checks now pass:
+- `https://pizza-logs-production.up.railway.app/api/player-portraits/userscript.user.js` returns HTTP 200
+- `https://pizza-logs-production.up.railway.app/players/Lichkingspet` returns HTTP 200 and includes the new avatar data hooks
+
+Verification before push:
+- `tsc --noEmit` passed
+- `eslint . --max-warnings=0` passed
+- focused portrait/profile/userscript tests passed
+- clean temp-copy `next build` passed with exit code 0
+
+Install/test the userscript from:
+`https://pizza-logs-production.up.railway.app/api/player-portraits/userscript.user.js`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+where is the install userscript link on the admin page?
+
+## Assistant
+
+It wasnâ€™t there. I added it and pushed the fix.
+
+Now go to:
+
+`/admin` -> **Warmane Gear Cache** -> **Character Portraits** -> **Install / Update Portrait Userscript**
+
+Pushed to `origin/main`:
+
+`6379ca5 fix: expose portrait userscript on admin`
+
+Verification:
+- Type-check passed
+- Lint passed
+- `gear-import-bookmarklet.test.ts` passed
+- Clean temp `next build` passed
+- Portrait userscript route is live and returns HTTP 200
+
+I couldnâ€™t directly inspect `/admin` HTML unauthenticated because production redirects `/admin` with HTTP 307, but the code is pushed and Railway served the public userscript route after deploy.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+i see you used classes... anyway you could get their actual ingame character face? like human dwarf etc and the style they used? also want it on the guild page too in the table and on the sessions pages where  you can deep dive on a specific player in the raid
+
+## User
+
+not sure where you are at following the compact since you keep flagging my chat for cyber security for no reason
+
+## Assistant
+
+Picked it back up after the compact and finished it.
+
+Implemented and pushed `bffd27e` to `origin/main`: `feat: expand Warmane portrait avatars`.
+
+What changed:
+- Guild roster rows now use `PlayerAvatar` instead of initials.
+- Session Raid Roster chips now include avatars.
+- Session player deep-dive headers now use avatars.
+- Portrait userscript bumped to `0.2.0`.
+- Userscript now runs on Warmane character pages too and tries to cache the actual rendered character canvas/static portrait through Tampermonkey storage.
+- Fallback remains: cached/real portrait -> class icon -> initials.
+
+Verified:
+- `tsc --noEmit` passed.
+- ESLint passed.
+- Focused avatar/userscript tests passed.
+- Production build passed from temp copy.
+- Pushed to GitHub and Railway is now serving userscript `0.2.0`.
+- Production `/guild-roster` returned 137 avatar hooks.
+- Production `/players/Maximusboom` has the avatar metadata and class-icon fallback live.
+
+To test the real in-game face: go to `/admin`, install/update the Portrait Userscript, open that playerâ€™s Warmane profile once, then reload Pizza Logs. If Warmane blocks canvas export, it will still fall back cleanly to class icons/initials.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+how do i execute the protraits scrape?
+
+## Assistant
+
+The portrait scrape runs automatically. There is no button/panel for it yet.
+
+Do this:
+
+1. Make sure `Pizza Logs Warmane Portraits` is enabled in Tampermonkey.
+2. Open a Warmane character page, like:
+   `https://armory.warmane.com/character/Lausudo/Lordaeron/profile`
+3. Wait a few seconds after the page/model loads.
+4. Reload Pizza Logs:
+   - `/players/Lausudo`
+   - `/guild-roster`
+   - raid session roster/player deep-dive pages
+
+The script caches by `realm:name`, so each character needs their Warmane page opened once for the â€œactual faceâ€ attempt.
+
+Important: the visible box in your screenshot is the Gear Sync script. Portraits currently run silently in the background. If Warmane blocks canvas export or does not expose a usable portrait image, Pizza Logs will stay on class icon/initials fallback.
+
+## User
+
+its still falling back to the class icons
+
+## Assistant
+
+I found the likely miss and pushed a fix.
+
+The portrait script was only running on Warmane/Pizza Logs pages. If Warmane renders the model through a Wowhead/Zamimg modelviewer frame, the canvas is inside that frame, so the old script could not see it. I pushed Portrait Userscript `0.3.0` to production with modelviewer-frame capture support.
+
+Do this now:
+
+1. In Tampermonkey, update `Pizza Logs Warmane Portraits` to `0.3.0`.
+   - Easiest: go to Pizza Logs `/admin` and click `Install / Update Portrait Userscript`.
+2. Reload the Warmane character page.
+3. Wait a few seconds for the modelviewer to load.
+4. Reload `/players/Lausudo` or `/guild-roster`.
+
+If it still falls back after `0.3.0`, then the modelviewer canvas is probably not readable due cross-origin browser protection. In that case Iâ€™ll add a visible portrait debug panel next so we can see exactly whether it found a frame, canvas, and whether `toDataURL()` is being blocked.
+
+Pushed commit: `5484f35 fix: capture Warmane portraits from modelviewer frames`.
+
+Sources I checked: [Wowhead Modelviewer Tutorial](https://www.wowhead.com/news/wowhead-modelviewer-tutorial-235544), [Warmane Armory profile example](https://armory.warmane.com/character/Pict/Icecrown/profile).
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+it was black once and then after reload it fellback to the class icons
+
+## Assistant
+
+That â€œblack onceâ€ was useful: it means the script did capture a canvas, but it was catching the modelviewer before it rendered anything useful.
+
+I pushed `0.4.0` to production in commit `1d28336`. It now:
+
+- rejects blank/black canvas captures
+- rejects tiny canvas exports
+- keeps retrying instead of caching black
+- uses a new cache key so old bad captures are ignored
+
+Production is already serving `0.4.0`.
+
+Do this:
+
+1. Update/reinstall `Pizza Logs Warmane Portraits` from `/admin`.
+2. Open the Warmane character page again.
+3. Wait until the character/model area is actually loaded, not just the gear list.
+4. Reload Pizza Logs.
+
+If it still stays on class icons after that, the next fix is adding a visible debug panel so we can see: modelviewer frame found, canvas found, canvas readable, blank rejected, or canvas blocked.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure element '<URL>'. This request was automatically upgraded to HTTPS, For more information see <URL>Understand this warning
+Lausudo:1 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_chest_plate_25.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:1 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_shirt_guildtabard_01.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:1 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_pants_plate_32.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:1 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/item_icecrownringd.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:2 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_chest_plate_25.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:2 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_shirt_guildtabard_01.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:2 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/inv_pants_plate_32.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.htmlUnderstand this warning
+Lausudo:2 Mixed Content: The page at 'https://pizza-logs-production.up.railway.app/players/Lausudo' was loaded over HTTPS, but requested an insecure element 'http://cdn.warmane.com/wotlk/icons/large/item_icecrownringd.jpg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.html
+
+## Assistant
+
+Fixed and pushed to `origin/main` at `753674f`.
+
+What changed:
+- Portrait userscript is now `0.5.0`.
+- It rejects black WebGL/modelviewer captures by sampling through a scratch canvas.
+- It uses a fresh cache key, `pizzaLogsWarmanePortraitCacheV3`, so old black/null portrait cache entries are ignored.
+- Warmane gear icon URLs are normalized from `http://` to `https://`, including old cached `cdn.warmane.com` icon URLs.
+
+Verified:
+- Production userscript endpoint is now serving `@version 0.5.0`.
+- `https://pizza-logs-production.up.railway.app/players/Lausudo` returns HTTP 200 and no longer has `http://cdn.warmane.com` in the rendered HTML.
+- Focused tests, type-check, full ESLint, `git diff --check`, and clean temp production build passed.
+
+To test portraits live: update/reinstall the Portrait userscript from `/admin`, open the Warmane character page once, wait for the modelviewer to render, then reload Pizza Logs.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - audit-and-clean-pizza-logs-repo.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - audit-and-clean-pizza-logs-repo.md
@@ -1,0 +1,271 @@
+# Audit and clean Pizza Logs repo
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019deec3-3867-7a50-9483-40a3ea3c9122`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T13-54-24-019deec3-3867-7a50-9483-40a3ea3c9122.jsonl`
+- Imported user turns: 4
+- Imported assistant final replies: 4
+- Tool/command events omitted: 391
+
+## Discussion Digest
+
+## User
+
+You are a senior staff engineer, repo maintainer, release engineer, documentation owner, product-aware technical lead, and Codex workflow specialist.
+
+You are working on the Pizza Logs project.
+
+Project context:
+- Pizza Logs is a web app for parsing and analyzing World of Warcraft combat logs.
+- The current product focus is Warmane / WotLK 3.3.5a combat logs.
+- The repo may include:
+  - parser package
+  - web app
+  - upload/report logic
+  - admin pages
+  - analytics
+  - documentation
+  - Railway deployment configuration
+  - GitHub repo docs/workflows
+- Railway auto-deploys from main, so pushing to main is a production-affecting action.
+
+Your mission is to bring the entire Pizza Logs repository up to date, remove Claude-specific artifacts, migrate the repo and docs to a Codex-first workflow, remove stale/dead code, simplify clearly overengineered areas, update docs, update Git hygiene, run validation, and commit/push to main only after the repo is production-ready.
+
+Do not stop until the repository has been audited, cleaned, documented, tested, and prepared for safe deployment.
+
+Use all available Codex capabilities, including:
+- codebase-wide search
+- terminal commands
+- tests
+- linters
+- type checking
+- static analysis
+- dependency analysis
+- Git inspection
+- documentation review
+- Codex skills/plugins if available
+- subagents or parallel workstreams if available
+
+Before starting, inspect available Codex skills/plugins.
+
+Use any relevant skills/plugins for:
+- repository audit
+- stale-code cleanup
+- TypeScript/JavaScript analysis
+- parser validation
+- documentation refresh
+- Git hygiene
+- security/secret scanning
+- test generation
+- GitHub PR/review preparation
+- Railway deployment readiness review
+
+Do not install or enable risky plugins.
+Do not use plugins that require secrets unless the repo already has safe secret configuration.
+Document which skills/plugins were used and why.
+
+If true subagents are available, use them.
+If true subagents are not available, simulate subagents by running the workstreams sequentially and clearly reporting findings by workstream.
+
+---
+
+## Production Deployment Rule
+
+Because Railway auto-deploys from main:
+
+- Work on a temporary branch first.
+- Run all checks on the branch.
+- Only merge/commit/push to main after validation passes.
+- Do not push to main if tests fail, build fails, parser validation fails, secret scan fails, or risky files are detected.
+- Do not change Railway production environment variables.
+- Do not commit `.env` files.
+- Do not commit production secrets.
+- Do not alter deployment behavior unless required and documented.
+- If database migrations exist, inspect them and document deployment risk before pushing main.
+- If the deployment is risky, stop before pushing main and provide exact findings.
+
+Temporary branch name:
+
+codex/pizza-logs-modernization
+
+Final target branch:
+
+main
+
+---
+
+## Primary Objectives
+
+1. Audit the entire Pizza Logs codebase.
+2. Remove Claude-specific files, references, configs, prompts, commands, scripts, docs, workflows, and local agent instructions.
+3. Replace Claude workflow documentation with Codex-first workflow documentation.
+4. Add or update repo-specific Codex guidance in AGENTS.md.
+5. Add Codex review guidance.
+6. Add Codex skills/plugins usage guidance if appropriate.
+7. Remove genuinely stale, unused, duplicate, dead, unreachable, or obsolete code.
+8. Refactor clearly overengineered or unnecessary code only when safe and justified.
+9. Preserve Pizza Logs product behavior, especially combat log parser correctness.
+10. Update all documentation:
+    - README
+    - app/package READMEs
+    - docs
+    - setup guides
+    - parser docs
+    - architecture docs
+    - contribution docs
+    - testing docs
+    - deployment docs
+    - Railway docs
+    - agent instructions
+    - workflow docs
+11. Review every modified, untracked, and ignored file.
+12. Stage every safe project file that belongs in Git.
+13. Add dangerous/private/generated/local files to `.gitignore`.
+14. Run all reasonable checks.
+15. Commit to the modernization branch.
+16. Merge/commit/push to main only after all production-readiness gates pass.
+
+---
+
+## Aggressiveness Rule
+
+Bias toward completing the cleanup, not merely reporting it.
+
+If a Claude artifact is clearly obsolete, remove it.
+If a doc is stale, rewrite it.
+If a script references removed tooling, update or delete it.
+If a dependency is unused, remove it and update the lockfile.
+If a file is safe and useful to the project, stage it.
+If a file is dangerous/private/generated/local, add it to `.gitignore`.
+If a workflow is stale or broken, fix or remove it.
+If a redundant abstraction is clearly unnecessary, simplify it.
+If duplicate code can be safely consolidated, consolidate it.
+If generated/cache/build files are accidentally tracked, remove them from Git tracking and add ignore rules.
+
+Do not leave obvious cleanup for later.
+
+However, Pizza Logs parser correctness overrides cleanup aggressiveness.
+
+Never delete or s
+
+[Truncated for vault import.]
+
+## Assistant
+
+Completed and pushed.
+
+1. Branch used: `codex/pizza-logs-modernization`
+2. Main updated: yes
+3. Main pushed: yes, `origin/main`
+4. Railway risk: low. No Railway env was changed. Production requires `ADMIN_SECRET`; do not set `ADMIN_COOKIE_SECURE=false` in Railway. No new Prisma migration was added.
+5. Work completed: repo audit, Claude artifact removal, Codex migration, docs refresh, stale-code cleanup, admin auth hardening, lint/build tooling repair, Git hygiene, validation, merge, push.
+6. Architecture confirmed: Next.js 15 web/API app, Prisma/Postgres, Python FastAPI parser, Railway Web Service + `parser-py`.
+7. Claude removed: `CLAUDE.md`, `.claude/launch.json`, Claude vault docs/prompts, stale Superpowers copied docs/plans.
+8. Codex added/updated: [AGENTS.md](C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/AGENTS.md), Codex vault docs, [docs/code-review.md](C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/docs/code-review.md), README/CONTRIBUTING/SECURITY/Railway docs.
+9. Skills/plugins used: Superpowers skills for startup, planning, parallel-agent work, verification, debugging; GitHub `yeet` guidance; Codex Security scan guidance; true subagents for inventory/product/docs/security/review.
+10. `AGENTS.md`: now covers setup, dev/test/build, parser safety, Railway, secrets, stale-code deletion, review checklist, and â€œdo not break combat log parsing.â€
+11. Codex review guidance: added `@codex review` guidance and pre-main checklist.
+12. Stale code removed: deprecated Wowhead runtime enrichment module/tests, duplicate parser `/parse-stream` progress block, stale copied Superpowers docs.
+13. Refactors: shared `lib/admin-auth.ts`, safer admin login cookie, generic item-template gearscore naming, ESLint CLI config.
+14. Dependencies: no package dependencies removed; proven stale runtime code removed without lockfile dependency churn.
+15. Scripts: `lint` now uses `eslint . --max-warnings=0`; added `eslint.config.mjs`.
+16. Docs: README, CONTRIBUTING, SECURITY, Railway/env/vault docs updated.
+17. `.gitignore`/`.dockerignore`: added local agent/build/log/combat-log/cache hygiene; removed accidental `{` pattern.
+18. Parser validation: `123 passed`.
+19. Web tests/build: TypeScript tests `14 passed`; lint passed; `tsc --noEmit` passed; `next build` passed.
+20. Production/Railway checks: production build passed. Docker/compose could not run because Docker is not installed.
+21. Secret scan: passed; only placeholders/local compose values found. Ignored `.env.local` and `.env.sync-agent` were not staged.
+22. Main checks run: parser tests, TS tests, lint, typecheck, production build, diff check, staged secret scan, live HTTP 200 check.
+23. Known remaining issues: Railway CLI is not installed locally, so logs were not checked. Manual production env confirmation for `ADMIN_SECRET` is still required.
+24. Claude refs retained: only defensive ignore patterns for legacy local `.claude` paths and historical handoff text explaining removal.
+25. Stale candidates retained: parser heuristic complexity and known parser/product debt retained unless fixture-backed changes prove safe.
+26. Risky files excluded: `.env.local`, `.env.sync-agent`, logs, `.next`, `node_modules`, `WoWCombatLog`, pytest cache.
+27. Git status: clean on `main`; `origin/main` matches local `main`.
+28. Modernization commit: `2360f64`
+29. Main commit: `3b98665`
+30. PR: none; pushed directly to `main` per deploy rule.
+
+::git-create-branch{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/pizza-logs-modernization"}
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix" branch="main"}
+
+## User
+
+checking in. where are we?
+
+## Assistant
+
+Weâ€™re deployed.
+
+`main` is pushed to `origin/main` at `3b98665`, and the main worktree is clean. Railway should have auto-deployed from that push. I also checked the live site and got HTTP 200.
+
+What landed:
+- Codex-first repo/docs migration.
+- Claude tracked artifacts removed.
+- Stale Wowhead runtime code/tests removed.
+- Admin auth hardened: production fails closed without `ADMIN_SECRET`; admin cookie is `HttpOnly`.
+- Parser behavior preserved; no broad parser rewrite.
+- Maxximusboom gear sync queue fix preserved from main.
+
+Validation passed before push:
+- Parser: `123 passed`
+- TS tests: `14 passed`
+- Lint: passed
+- Typecheck: passed
+- Next production build: passed
+- Secret scan: placeholders only, no production secrets staged
+
+One caveat: Railway CLI is not installed locally, so I couldnâ€™t inspect Railway deploy logs from the terminal. Also, the main vault handoff says â€œcommit/push nextâ€ because it was written just before the final push; git is the source of truth here: `origin/main` is already at `3b98665`.
+
+## User
+
+is the progress on the right actually happening?
+
+## Assistant
+
+No. That right-side Progress panel is stale UI state, not an active background job.
+
+Actual state:
+- The modernization work is done.
+- `main` was pushed to `origin/main` at `3b98665`.
+- The main worktree is clean.
+- Validation passed before push.
+- Live site returned HTTP 200.
+
+Whatâ€™s stale:
+- The right progress checklist was not updated to mark later phases complete.
+- The default vault copy also has slightly stale â€œnext stepâ€ text because the final push happened from the separate main worktree.
+
+So there is no hidden work currently progressing there. The remaining real follow-ups are manual production checks: confirm Railway has `ADMIN_SECRET`, check deploy logs if you have Railway access, then run/verify the Warmane Gear Sync flow.
+
+## User
+
+ok just bring all the docs up to speed and mds up to speed im stepping away
+
+## Assistant
+
+Docs are now up to speed and pushed.
+
+Updated:
+- `Latest Handoff.md` and `Now.md` now reflect that `main` is already pushed.
+- Backlog, Feature Status, Technical Debt, Security Checklist, and Known Issues now reflect shipped admin auth, footer text, cleanup actions, Gear Sync `1.7.0`, and the Maxximusboom queue fix.
+- Removed stale â€œcommit/push next,â€ â€œpending,â€ â€œadmin auth future,â€ and â€œfooter bugâ€ doc language.
+- Fast-forwarded the local default worktree too, so future Codex startup reads current vault files.
+
+Pushed docs-only commit: `add925a` on `origin/main`.
+
+Verification:
+- `git diff --check` passed.
+- Stale Markdown phrase search passed.
+- Both worktrees are clean.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - fix-icc-boss-ordering.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - fix-icc-boss-ordering.md
@@ -1,0 +1,249 @@
+# Fix ICC boss ordering
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019df0de-35c8-7d02-834b-0be56d3eef55`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T23-43-07-019df0de-35c8-7d02-834b-0be56d3eef55.jsonl`
+- Imported user turns: 4
+- Imported assistant final replies: 4
+- Tool/command events omitted: 157
+
+## Discussion Digest
+
+## User
+
+You are working in my Pizza Logs project.
+
+Enhancement:
+Fix boss ordering across:
+- Raid Sessions page
+- Leaderboards page
+
+Current problem:
+Bosses are being displayed alphabetically.
+
+Expected behavior:
+Bosses must be displayed in canonical Icecrown Citadel progression order (kill order), from Marrowgar to The Lich King.
+
+Target order (authoritative):
+1. Lord Marrowgar
+2. Lady Deathwhisper
+3. Gunship Battle
+4. Deathbringer Saurfang
+5. Festergut
+6. Rotface
+7. Professor Putricide
+8. Blood Prince Council
+9. Blood-Queen Lana'thel
+10. Valithria Dreamwalker
+11. Sindragosa
+12. The Lich King
+
+Tasks:
+
+1. Codebase discovery
+   - Locate where boss lists are generated for:
+     - Raid Sessions page
+     - Leaderboards page
+   - Identify whether sorting is:
+     - frontend-only (array sort)
+     - backend/API-driven
+     - database query ORDER BY
+   - Identify boss name source (combat log parser output vs normalized table).
+
+2. Introduce canonical ordering
+   - Create a single source of truth for boss order.
+   - Prefer a constant or config, for example:
+     - `BOSS_ORDER_ICC`
+   - Map boss name â†’ numeric order index.
+   - Do not rely on string comparison.
+
+   Example structure:
+   ts
+   const ICC_BOSS_ORDER = {
+     "Lord Marrowgar": 1,
+     "Lady Deathwhisper": 2,
+     "Gunship Battle": 3,
+     "Deathbringer Saurfang": 4,
+     "Festergut": 5,
+     "Rotface": 6,
+     "Professor Putricide": 7,
+     "Blood Prince Council": 8,
+     "Blood-Queen Lana'thel": 9,
+     "Valithria Dreamwalker": 10,
+     "Sindragosa": 11,
+     "The Lich King": 12,
+   }
+Apply sorting logic
+Replace all alphabetical sorts with order-based sorting using the mapping.
+Sorting rule:
+Primary: ICC_BOSS_ORDER[name]
+Secondary fallback: original index or alphabetical if boss not in map
+Ensure stable sorting.
+Data normalization
+Validate boss names coming from parser:
+Ensure they match keys in the map.
+If inconsistencies exist (e.g., â€œGunshipâ€, â€œGunship Battle - Allianceâ€), normalize before sorting.
+Add a normalization helper if required.
+Backend vs frontend decision
+If boss data is reused across multiple views:
+Prefer sorting at the API/backend level.
+If views are independent:
+Apply consistent sorting utility used by both pages.
+Edge cases
+Unknown bosses:
+Appear after known ICC bosses.
+Partial raids:
+Preserve correct relative order of encountered bosses.
+Duplicate entries:
+Maintain correct grouping and ordering.
+Testing
+Verify ordering:
+Full ICC clear
+Partial clears
+Mixed raid uploads
+Confirm both:
+Raid Sessions page
+Leaderboards page
+show identical correct ordering.
+Ensure no regression in rendering or grouping.
+Refactor
+Avoid duplicating ordering logic.
+Extract reusable utility, for example:
+sortBossesByICCOrder(bosses: Boss[]): Boss[]
+Documentation
+Add a short comment explaining:
+Why alphabetical sorting is incorrect
+Why ICC-specific ordering is enforced
+Keep it concise.
+
+Constraints:
+
+Do not break existing UI structure.
+Do not hardcode sorting separately in multiple files.
+Keep implementation minimal and maintainable.
+
+Deliverables:
+
+Files modified
+Where ordering is applied (frontend/backend)
+Any normalization added
+Confirmation both pages now render correct kill order
+
+## Assistant
+
+Implemented.
+
+Files changed:
+- [lib/constants/bosses.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/constants/bosses.ts:85) adds `ICC_BOSS_ORDER`, normalization, and stable sorting helpers.
+- [app/leaderboards/page.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/leaderboards/page.tsx:16) now fetches by DB `sortOrder` and applies `sortBossesByICCOrder`.
+- [app/uploads/[id]/sessions/[sessionIdx]/page.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/uploads/[id]/sessions/[sessionIdx]/page.tsx:52) now displays session encounters in ICC kill order.
+- [app/uploads/[id]/sessions/[sessionIdx]/players/[playerName]/page.tsx](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/uploads/[id]/sessions/[sessionIdx]/players/[playerName]/page.tsx:45) now keeps the player session breakdown/chart in the same order.
+- [tests/boss-order.test.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/boss-order.test.ts:10) covers full ICC, partial clears, mixed uploads, duplicates, normalization, and seeded boss-name alignment.
+- Updated required vault docs: Latest Handoff, Now, Known Issues.
+
+Ordering is applied server-side in the rendered page data path. Boss names come from parser canonical `BossDef.name`, then upload maps `bossName` into the normalized `bosses` table. I added normalization for Gunship variants, `Lich King`/`Arthas`, and Blood-Queen Lanaâ€™thel variants.
+
+Verification:
+- `tests/boss-order.test.ts` passed
+- `tsc --noEmit` passed
+- focused ESLint passed
+- `git diff --check` passed
+
+## User
+
+push to git update your agent to always push to git please i dont test locally
+
+## Assistant
+
+Pushed.
+
+Committed `f226e17` (`fix: order ICC bosses by progression`) and pushed it to both:
+- `origin/codex/pizza-logs-modernization`
+- `origin/main`
+
+I also updated [AGENTS.md](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/AGENTS.md:13) so future validated change sessions default to commit + push unless you explicitly ask to keep work local.
+
+Validation passed:
+- `tests/boss-order.test.ts`
+- `tsc --noEmit`
+- full ESLint
+- `next build`
+- parser suite: `123 passed`
+- staged secret scan
+- `git diff --check`
+
+Working tree is clean.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/pizza-logs-modernization"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+can we fix up the summary section for players as well and sort those in the same order
+
+## Assistant
+
+Fixed and pushed.
+
+`/players/<name>` Per-Boss Summary now uses `buildPlayerPerBossSummary()` in [lib/player-profile.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-profile.ts:74), which applies the shared ICC ordering helper. The player page no longer sorts those cards by best DPS.
+
+Pushed commit `47e18dc` to:
+- `origin/codex/pizza-logs-modernization`
+- `origin/main`
+
+Validation passed:
+- `tests/player-profile.test.ts`
+- `tests/boss-order.test.ts`
+- `tsc --noEmit`
+- full ESLint
+- `next build`
+- parser suite: `123 passed`
+- staged secret scan
+- `git diff --check`
+
+Only remaining local changes are unstaged Obsidian UI files: `.obsidian/graph.json` and `.obsidian/workspace.json`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/pizza-logs-modernization"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+I want to also sort players recent encournters and this weeks boss kills this week
+
+## Assistant
+
+Implemented and pushed to `origin/main`.
+
+Commit: `1e8405d` (`fix: order weekly and player encounter lists`)
+
+What changed:
+- Player Recent Encounters now sorts the recent 20 encounter window by ICC progression order.
+- `/weekly` Boss Kills This Week now sorts by ICC progression order instead of kill count.
+- `/api/weekly` uses the same weekly boss-kill ordering helper.
+- Added tests for both paths.
+
+Validation passed:
+- `tests/player-profile.test.ts`
+- `tests/weekly-stats.test.ts`
+- `tests/boss-order.test.ts`
+- `tsc --noEmit`
+- full ESLint
+- `next build`
+- parser suite: `123 passed`
+- staged secret scan
+- `git diff --check`
+
+Working tree is clean.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - query-wow-items-50024.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - query-wow-items-50024.md
@@ -1,0 +1,371 @@
+# Query wow_items 50024
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019dee6a-63f1-7792-a247-bb0bca574ec0`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T12-17-23-019dee6a-63f1-7792-a247-bb0bca574ec0.jsonl`
+- Imported user turns: 8
+- Imported assistant final replies: 8
+- Tool/command events omitted: 225
+
+## Discussion Digest
+
+## User
+
+query the railway db in the table wow_items for itemId 50024
+
+## Assistant
+
+Queried Railway-backed `wow_items` for `itemId = 50024`.
+
+```json
+{
+  "itemId": "50024",
+  "name": "Blightborne Warplate",
+  "itemLevel": 264,
+  "quality": "epic",
+  "armor": 2641,
+  "stats": {
+    "Dodge": 108,
+    "Defense": 108,
+    "Stamina": 207,
+    "Strength": 123,
+    "Hit Rating": 58
+  },
+  "bonding": 1,
+  "requiredLevel": 80,
+  "importedAt": "2026-05-03T14:21:40.591Z"
+}
+```
+
+`missing` was empty, so the item is present in the Railway DB.
+
+## User
+
+does it have the icon etc?
+
+## Assistant
+
+Not from the query I ran. The production admin endpoint returned this for `50024`:
+
+- name, ilvl, quality
+- armor
+- stats
+- bonding
+- requiredLevel
+- importedAt
+
+It did **not** return `iconName`, `equipLoc`, sockets, description, damage fields, etc.
+
+Important bit: the current AzerothCore import populates item stats/details, but it **does not add icons** from `item_template.sql`. It only preserves `wow_items.iconName` if that row already had one from the older gear-cache/Wowhead-style seed.
+
+So: `50024` definitely has item metadata in Railway; I have **not yet verified** whether its `iconName` column is populated. The clean DB check would be:
+
+```sql
+select
+  "itemId",
+  name,
+  "iconName",
+  "equipLoc",
+  "socketColors",
+  description,
+  "displayId",
+  "itemClass",
+  "itemSubclass"
+from wow_items
+where "itemId" = '50024';
+```
+
+## User
+
+im essentialling trying to figure out why some items have the icon and tool tip while others dont. my understanding of the way the codebase works for pizz logs is  that i use tampermonkey to pull what each player is wearing and then use the azerothcore db import im dumped into my product dB to enrich. wowhead api was unreliable and i didnt want to cache every item from their db like i am doing with players gear on warmane via tampermonkey
+
+## Assistant
+
+Your mental model is basically right, with one important wrinkle:
+
+Pizza Logs has **two enrichment sources**:
+
+1. **Tampermonkey / Warmane API**
+   Supplies the playerâ€™s equipped items and, when Warmane provides it, `icon` / `iconUrl`.
+
+2. **AzerothCore `item_template` import**
+   Supplies stable item facts: name, ilvl, quality, stats, armor, sockets, bonding, required level, etc.
+
+The wrinkle: **AzerothCore `item_template` does not provide icon filenames.** The importer deliberately skips `iconName` and preserves only whatever was already there from Tampermonkey/cache.
+
+So items with icons are getting them from one of these:
+
+- the cached player gear blob has `iconUrl`
+- or `wow_items.iconName` was previously seeded from cached gear
+
+Items without icons are likely cases where:
+
+- the player gear cache has no `iconUrl`
+- and `wow_items.iconName` is null
+- but the AzerothCore import still filled stats/details, so ilvl/GS/details can exist without an icon
+
+For Lausudo specifically, production says these missing-icon items are **in DB and have details**:
+
+- `50024` Blightborne Warplate: `detailsLen: 8`, has armor/stats
+- `49964` Legguards of Lost Hope: `detailsLen: 8`, has armor/stats
+- `49985` Juggernaut Band: `detailsLen: 7`, has stats
+
+So this is not â€œAzerothCore failed to enrich the item.â€ It is specifically â€œno icon source survived for this item.â€
+
+The code also explains why it stays stuck: [warmane-armory.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-armory.ts:167) considers gear enriched if every item has `itemId`, `itemLevel`, and `equipLoc`. It does **not** require `iconUrl`. So missing icons do not put a player back into the Tampermonkey sync queue.
+
+Likely fix direction: make the gear importer/backfill update `wow_items.iconName` from any imported `iconUrl`, even for rows already created by AzerothCore. Then icons become item-level metadata instead of depending on one playerâ€™s cached gear blob.
+
+## User
+
+well plan and investigate and get it fix
+
+## Assistant
+
+Implemented the fix locally.
+
+Root cause was exactly what we suspected: AzerothCore enriches stats/details, but it has no icon slugs. Icons only come from Warmane/Tampermonkey or existing `wow_items.iconName`, and the cache queue was treating gear as â€œcompleteâ€ even when `iconUrl` was missing.
+
+Changed [warmane-armory.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/warmane-armory.ts) so missing `iconUrl` re-queues gear for sync, and imported gear now backfills `wow_items.iconName` from valid Zamimg icon URLs while preserving AzerothCore fields. Added regression tests in [armory-gear-queue.test.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/armory-gear-queue.test.ts) and [warmane-armory-import.test.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/warmane-armory-import.test.ts). Updated the vault handoff, Now, and Known Issues files too.
+
+Verified:
+```text
+item-template tests passed
+warmane-armory-cache tests passed
+warmane-armory-import tests passed
+armory-gear-queue tests passed
+tsc --noEmit passed
+git diff --check passed
+```
+
+One unrelated existing test drift remains: `armory-gear-client-scripts.test.ts` expects userscript `1.0.4`, but the code currently emits `1.5.0`.
+
+Next operational step is deploy this, then run Warmane Gear Sync for Lausudo so production can populate `iconName` for `50024`, `49964`, and `49985`.
+
+## User
+
+commit and push to main repo in git
+
+## Assistant
+
+Committed and pushed to `origin/main`.
+
+Commit: `09e2b3e fix: backfill gear item icons`
+
+Verified before commit:
+- `item-template.test.ts`
+- `warmane-armory-cache.test.ts`
+- `warmane-armory-import.test.ts`
+- `armory-gear-queue.test.ts`
+- `tsc --noEmit`
+- `git diff --cached --check`
+
+Unrelated untracked files are still left untouched: `docs/superpowers/plans/2026-05-02-gear-item-template.md`, `tmp-mobile-check/`, and `{`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+You are a senior software engineer debugging a production issue.
+
+## Objective
+Resolve the bug completely. Do not stop until:
+- Root cause is identified
+- Fix is implemented
+- Tests prove the issue is resolved
+- No regressions are introduced
+
+## Bug Description
+Some items are still not enriched. the same items every time.
+- Expected behavior:
+- Actual behavior:
+- Error messages / logs:
+- Frequency / conditions:
+
+## Environment
+- Language:
+- Framework:
+- Runtime:
+- Dependencies:
+- Relevant files/modules:
+
+## Rules (MANDATORY)
+- DO NOT start coding immediately
+- DO NOT assume the first cause is correct
+- DO NOT refactor unrelated code
+- ALWAYS prefer the smallest safe fix
+- ALWAYS validate with tests before concluding
+
+## Step 1 â€” Deep Analysis (NO CODE)
+1. Explain what the system is currently doing
+2. Identify where the failure occurs
+3. List up to 10 possible root causes ranked by likelihood
+4. Identify the most probable root cause(s)
+5. Explain why those are most likely
+
+## Step 2 â€” Investigation Plan
+- What files/functions will you inspect?
+- What logs or instrumentation will you add?
+- What test cases will reproduce the bug?
+
+## Step 3 â€” Reproduce the Bug
+- Create or identify a minimal reproducible test case
+- Confirm the bug exists deterministically
+
+## Step 4 â€” Fix Plan
+- Propose the smallest possible fix
+- List exact files and lines to change
+- Identify potential side effects or regressions
+
+## Step 5 â€” Implementation
+- Apply ONLY the minimal fix
+- Do not modify unrelated code
+
+## Step 6 â€” Validation
+- Run all relevant tests
+- Add new tests for this bug
+- Confirm:
+  - Bug is resolved
+  - No regressions
+
+## Step 7 â€” Iteration Loop
+If the fix fails:
+- Re-evaluate root causes
+- Select next most likely cause
+- Repeat steps 4â€“6
+
+## Step 8 â€” Final Output
+Provide:
+- Root cause summary
+- Exact fix explanation
+- Files changed
+- Tests added
+- Evidence (logs/test output) that the bug is resolved
+
+Continue iterating until the issue is fully resolved.
+Do not stop early.
+
+## Assistant
+
+Root cause found and fixed.
+
+The earlier server-side fix made iconless gear re-enter the sync queue, but the same items still stayed iconless because the hosted Warmane Gear Sync userscript only forwarded Warmane API JSON. For these deterministic missing items, Warmaneâ€™s API can omit `icon` / `iconUrl`, while the visible Warmane page still has the item icon in the DOM.
+
+Exact fix:
+- Updated [lib/armory-gear-client-scripts.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/armory-gear-client-scripts.ts) so the userscript/bookmarklets scrape item links/images from the current Warmane character page.
+- The script now matches DOM icons by item ID and merges missing `iconUrl` into the Warmane API payload before posting to Pizza Logs.
+- Bumped hosted Gear Sync userscript to `1.6.0`.
+- Added a real VM regression test in [armory-gear-client-scripts.test.ts](/C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/armory-gear-client-scripts.test.ts): fake API item has no icon, fake Warmane DOM has the icon, captured Pizza Logs import payload includes the merged Zamimg `iconUrl`.
+
+Validation evidence:
+```text
+armory-gear-client-scripts tests passed
+item-template tests passed
+warmane-armory-cache tests passed
+warmane-armory-import tests passed
+armory-gear-queue tests passed
+tsc --noEmit passed
+git diff --check passed
+```
+
+Also pushed to `origin/main`.
+
+Commit: `1e0e83a fix: merge Warmane DOM item icons`
+
+Production verification:
+- Live app returned HTTP 200 after deploy restart.
+- Hosted userscript now serves `// @version      1.6.0`.
+- `Lausudo` is still queued, which is expected until Gear Sync is run again.
+
+Next action in browser: install/update Gear Sync from `/admin`, then run it on Lausudoâ€™s Warmane page. That run should populate `wow_items.iconName` for the missing deterministic items and make the Pizza Logs cards show icons after reload.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+so you fixed Lausudo but i audited some more players and found more issues like before does this mean i have to go to each player and run tampermonkey?
+
+## Assistant
+
+No. With the script that was live before this last fix, yes in practice: `1.6.0` only scraped icons from the Warmane page currently open, so bulk sync could still miss API-omitted icons for other players.
+
+I fixed that gap and pushed it.
+
+Current behavior in Gear Sync `1.7.0`:
+- Run from any Warmane character page.
+- It gets the Pizza Logs missing-gear queue.
+- For each queued player, it fetches:
+  - Warmane API gear JSON
+  - that playerâ€™s Warmane summary HTML
+- It scrapes item icons from that playerâ€™s HTML and merges them into the import payload.
+- Pizza Logs then backfills `wow_items.iconName`.
+
+So you should not need to visit each player manually.
+
+What you need to do:
+1. Go to `/admin`.
+2. Install/update Warmane Gear Sync.
+3. Confirm Tampermonkey has version `1.7.0`.
+4. Open any Warmane character page.
+5. Click `Sync now`.
+6. Let it run through the queue. Current queue was about 70 players, so expect a few minutes.
+
+Pushed commit: `e318905 fix: scrape queued player gear icons`
+
+Verified:
+```text
+armory-gear-client-scripts tests passed
+item-template tests passed
+warmane-armory-cache tests passed
+warmane-armory-import tests passed
+armory-gear-queue tests passed
+tsc --noEmit passed
+```
+
+Production is serving Gear Sync `1.7.0`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+so better.. i audited about 30 players and everything works. still just this one use case I have been following where its not updating https://pizza-logs-production.up.railway.app/players/Maxximusboom
+
+## Assistant
+
+Fixed and pushed to `origin/main`.
+
+Root cause: `/api/admin/armory-gear/missing` was taking only the first 100 `player` rows and first 100 roster rows before filtering for missing gear. Maxximusboom was outside that pre-filter window, so he never got queued even though his cached gear was incomplete.
+
+Fix: removed the pre-filter limits in [route.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/app/api/admin/armory-gear/missing/route.ts:55). The API still returns at most 100 missing players per run via the existing post-filter `.slice(0, MAX_PLAYERS)`.
+
+Added regression test: [armory-gear-missing-route.test.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/tests/armory-gear-missing-route.test.ts:7), which reproduces Maxximusboom appearing after 120 fresh players. It failed before the fix with `payload.players = []`, then passed after.
+
+Validation passed:
+- `tests/armory-gear-missing-route.test.ts`
+- `tests/armory-gear-queue.test.ts`
+- `tests/armory-gear-client-scripts.test.ts`
+- `tests/warmane-armory-cache.test.ts`
+- `tests/warmane-armory-import.test.ts`
+- `tsc --noEmit`
+- `git diff --check`
+
+Commit: `4e26206 fix: include all players in gear sync queue`
+
+Production verification: after Railway deployed, `/api/admin/armory-gear/missing` returned `39` queued players and included `Maxximusboom`.
+
+Answer to your question: no, you do not need to visit each player individually. You should only need to run Warmane Gear Sync once from a Warmane character page; Maxximusboom is now in the queue, so the userscript can fetch his page and import the missing icons.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - use-this-for-favicon.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-03 - use-this-for-favicon.md
@@ -1,0 +1,78 @@
+# Use this for favicon
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-03
+- Thread id: `019def9a-6235-7f83-9315-cc5dcefefd09`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\03\rollout-2026-05-03T17-49-25-019def9a-6235-7f83-9315-cc5dcefefd09.jsonl`
+- Imported user turns: 4
+- Imported assistant final replies: 3
+- Tool/command events omitted: 107
+
+## Discussion Digest
+
+## User
+
+lets use this for the favicon
+
+## User
+
+dont use my attached image though please use however you created it on the web app
+
+## Assistant
+
+Added the favicon as [app/icon.svg](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/icon.svg), generated from the existing `PizzaIcon` SVG in the nav, not from the attached image.
+
+I also updated the required vault handoff files:
+[Latest Handoff.md](<C:/Users/neil_/OneDrive/Desktop/PizzaLogs/Pizza Logs HQ/02 Build Log/Latest Handoff.md>) and [Now.md](<C:/Users/neil_/OneDrive/Desktop/PizzaLogs/Pizza Logs HQ/03 Current Focus/Now.md>).
+
+Verification passed:
+- `app/icon.svg` XML parse
+- `tsc --noEmit` via bundled Node
+- `next build` via bundled Node
+- Local built app serves `http://127.0.0.1:3000/icon.svg` as `image/svg+xml`
+
+Local server is running at `http://127.0.0.1:3000`. Changes are not committed or pushed.
+
+## Assistant
+
+That screenshot is hitting `/favicon.ico`, so `app/icon.svg` alone was not enough.
+
+I fixed it locally by adding [public/favicon.ico](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/public/favicon.ico), generated from the same in-app nav logo SVG, plus [app/icon.svg](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/icon.svg) for Next metadata icons. I did not use the attached image.
+
+Verified:
+- `/favicon.ico` reproduced as 404 before the ICO was added
+- `public/favicon.ico` is a valid ICO with `16x16`, `32x32`, `48x48`
+- `tsc --noEmit` passed
+- `next build` passed
+- Local built app returns `/favicon.ico` as `200 image/x-icon`
+- Local built app returns `/icon.svg` as `200 image/svg+xml`
+
+Production will still show the 404 until this is committed and deployed. Local server is running at `http://127.0.0.1:3000`.
+
+## User
+
+still /favicon.ico:1  Failed to load resource: the server responded with a status of 404 () please test before stating its fixed
+
+## Assistant
+
+You were right. I had only tested local before.
+
+I tested production directly, confirmed `/favicon.ico` was still `404`, then pushed the favicon assets to `origin/main`. After Railway deployed, I re-tested production:
+
+- `https://pizza-logs-production.up.railway.app/favicon.ico` -> `200 image/x-icon`
+- `https://pizza-logs-production.up.railway.app/icon.svg` -> `200 image/svg+xml`
+- `https://pizza-logs-production.up.railway.app/players/Lichkingspet` -> `200`
+
+Commits pushed:
+- `527c883` - adds `app/icon.svg` and `public/favicon.ico`
+- `f2e49f4` - records the production verification in the vault docs
+
+Local server is stopped and the worktree is clean.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - add-mvp-animation-pass.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - add-mvp-animation-pass.md
@@ -1,0 +1,298 @@
+# Add MVP animation pass
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-04
+- Thread id: `019df12f-5943-7071-92fe-c404d7f257c5`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\04\rollout-2026-05-04T01-11-45-019df12f-5943-7071-92fe-c404d7f257c5.jsonl`
+- Imported user turns: 5
+- Imported assistant final replies: 5
+- Tool/command events omitted: 292
+
+## Discussion Digest
+
+## User
+
+[@superpowers](plugin://superpowers@openai-curated)
+
+Main rule!!! You MUST push to Main in git inorder for railway to pick up the change and deloy. My local is not setup up because lack of a dB.
+
+With that said... Lets see what you can do!
+
+You are working in my Pizza Logs codebase.
+
+Goal:
+Build an MVP animation pass for the app using lightweight, production-safe animations. Do not overbuild. Do not add heavy 3D, WebGL, sound, or large external assets.
+
+Primary MVP ideas to implement:
+
+1. First-visit landing intro
+Create a short â€œFrozen Logbookâ€ intro overlay for Pizza Logs.
+
+Behavior:
+- Shows only on first visit per browser using localStorage.
+- Max duration: 2.5 seconds.
+- Must have a visible Skip button.
+- Theme: dark ICC / frost / Lich King-inspired, but do not use copyrighted images or actual Blizzard assets.
+- Visuals should be CSS-only:
+  - dark background
+  - subtle snow/frost particles if easy
+  - frost glow
+  - Pizza Logs title reveal
+  - short tagline such as â€œRaid data, forged from combat logs.â€
+- After completion or skip, unmount the overlay cleanly.
+
+2. Boss kill order reveal animation
+On raid session and leaderboard views, animate boss cards/rows/icons in kill order instead of alphabetical order.
+
+Behavior:
+- Preserve actual kill order from parsed encounter/session data.
+- Do not sort bosses alphabetically if encounter timestamps/order are available.
+- Animate each boss entry with a small stagger:
+  - fade in
+  - slight upward motion
+  - subtle frost pulse on entry
+- Keep the animation subtle and fast.
+- Ensure sorting logic is centralized or clearly documented.
+
+3. Player / leaderboard row reveal
+Add lightweight row reveal animations to player rankings and leaderboards.
+
+Behavior:
+- Rows fade/slide in with minor stagger.
+- DPS/HPS/damage values may count up only if there is already a safe utility or simple reusable implementation.
+- Do not introduce fragile animation logic that affects data accuracy.
+- Animation must not block rendering or create layout shift.
+
+Technical requirements:
+- First inspect the repo structure before changing files.
+- Use existing stack and dependencies where possible.
+- If framer-motion is already installed, use it.
+- If not installed, prefer CSS animations over adding a dependency.
+- Keep components reusable:
+  - Intro overlay component
+  - Animated list/row utility or CSS class
+  - Boss progression animation helper if needed
+- Respect existing styling conventions.
+- Maintain mobile responsiveness.
+- Respect reduced-motion:
+  - Use prefers-reduced-motion CSS or equivalent logic.
+  - Users with reduced motion should get instant/simple fades only.
+
+Brand/style constraint:
+All animation work must stay within the existing Pizza Logs visual identity. Do not redesign the app, change the core theme, replace the layout, or introduce a new visual language.
+
+Use the current:
+- color palette
+- typography
+- spacing
+- card styling
+- button styles
+- border radius
+- shadows/glows
+- dark theme treatment
+- existing WoW-inspired tone
+
+The animations should feel like an enhancement to the current Pizza Logs UI, not a separate landing-page redesign. Any frost/ICC/Lich King-inspired effects must be subtle and blended into the existing brand system.
+
+Before implementing, inspect the current styles/components and reuse existing design tokens, CSS variables, Tailwind classes, or component patterns wherever possible.
+
+Avoid:
+- new unrelated colors
+- oversized cinematic elements that clash with the app
+- fake Blizzard/WoW assets
+- changing navigation structure
+- changing dashboard/card/table layouts
+- making the app feel like a fan-site splash page instead of a log-analysis tool
+
+Files to inspect first:
+- package.json
+- app/layout, pages layout, or router structure
+- homepage / landing page component
+- raid sessions page
+- leaderboards page
+- player components
+- boss/encounter parsing or display utilities
+- existing CSS/global styles
+
+Implementation constraints:
+- Do not rewrite unrelated UI.
+- Do not change parser behavior except where boss display ordering is clearly wrong.
+- Do not change database schema unless absolutely necessary.
+- Do not add copyrighted Lich King images, icons, audio, or branded Blizzard assets.
+- Do not make animations mandatory or annoying.
+- Keep this MVP easy to remove or iterate on.
+
+Testing:
+- Run typecheck/lint/build/test commands available in package.json.
+- Manually verify:
+  - first visit shows intro
+  - refresh after first visit does not show intro
+  - skip button works
+  - reduced-motion does not animate heavily
+  - boss order follows encounter order
+  - leaderboards still show correct data
+  - mobile layout remains usable
+
+Deliverables:
+- Implement the MVP.
+- Summarize changed files.
+- Explain how to reset the intro for testing (localStorage key).
+- Call out any assumptions about boss order data.
+- If any part cannot be implemented safely, leave a clear TODO with reasoning rather than guessing.
+
+## Assistant
+
+Implemented and pushed to `origin/main`.
+
+What changed:
+- Added CSS-only `FrozenLogbookIntro` first-visit overlay.
+- Added reusable reveal/order helper in `lib/ui-animation.ts`.
+- Wired subtle reveal animations into raids, sessions, leaderboards, player cards, player profile rows, and meter rows.
+- Session encounter display now uses `startedAt` order when available; leaderboard boss boards remain ICC progression because they are aggregate boss views with no single session timestamp.
+- Updated required vault handoff docs.
+
+Reset intro for testing:
+```js
+localStorage.removeItem("pizzaLogsFrozenIntroSeen")
+```
+
+Validation:
+- Focused tests passed: `ui-animation`, `frozen-intro-source`, `boss-order`, `player-profile`.
+- `tsc --noEmit`, full ESLint, `git diff --check`, and `next build` passed.
+- Local Chrome checks passed for first visit, skip, refresh suppression, auto-complete, reduced motion, and mobile layout.
+- Pushed `main`; Railway deployed the new bundle. Production Chrome smoke check passed for intro skip/localStorage and mobile `/players`.
+
+Latest `main`: `419e690`
+Animation code commit: `8a6de54`
+
+::git-create-branch{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/pizza-logs-animation-mvp"}
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+I saw the animation for a split second and never again and it was when i selected guild page. not even sure what other animations you implemented
+
+## Assistant
+
+Fixed and pushed to `origin/main` for Railway.
+
+Root cause: the intro was intentionally one-time via `localStorage`, but there was no replay path. More importantly, Tailwind was purging the shared `reveal-item` / `boss-reveal-item` animation classes in production because they were generated from `lib/ui-animation.ts`, outside Tailwindâ€™s scanned paths.
+
+What you can test now:
+- Replay intro anytime with `?intro=1`, e.g. `https://pizza-logs-production.up.railway.app/?intro=1`
+- Full reset: `localStorage.removeItem("pizzaLogsFrozenIntroSeen")`
+- Reveal animations are on Guild roster rows, raid/session boss rows, raid roster/player rows, leaderboards, player cards/profile sections, and meter rows.
+
+Changed:
+- Added Tailwind safelist for reveal classes.
+- Added regression coverage for the safelist.
+- Updated vault handoff, Now, and Known Issues docs.
+
+Verified:
+- Targeted animation tests passed.
+- TypeScript passed.
+- ESLint passed.
+- `next build` passed.
+- Parser suite passed: `123 passed`.
+- Production CSS now serves `.reveal-item`, `.boss-reveal-item`, both reveal keyframes, and the reveal timing after Railway picked up `main`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+what is the frozne intro because ive never seen it before on live
+
+## Assistant
+
+The â€œFrozen Logbookâ€ intro is a short full-screen startup overlay:
+
+- dark frost/ICC-style background
+- subtle snow/frost CSS particles
+- `Pizza Logs` title reveal
+- tagline: `Raid data, forged from combat logs.`
+- visible `Skip` button
+- auto-dismisses in about 2.3 seconds
+- stores `pizzaLogsFrozenIntroSeen` in `localStorage`
+
+It is mounted globally, so seeing it when you clicked Guild actually makes sense: it appears on the first route the browser loads after the feature is live, not only on the homepage.
+
+Why you probably didnâ€™t see it properly: your browser likely got the first-visit flag set during that split-second flash. Also, before the follow-up fix, some animation CSS was being purged in production, so the rest of the animation pass was basically too subtle or missing.
+
+I verified live currently has the replay code and tagline in the deployed JS. Try this directly:
+
+[Replay Frozen Intro](https://pizza-logs-production.up.railway.app/?intro=1)
+
+Or reset it in browser console:
+
+```js
+localStorage.removeItem("pizzaLogsFrozenIntroSeen")
+location.reload()
+```
+
+If your OS/browser has reduced motion enabled, the intro intentionally becomes much shorter and less animated.
+
+## User
+
+yeah i see by clicking that link but thats the only way i see it
+
+## Assistant
+
+That is expected with the current rule: it only shows once per browser, then `localStorage` suppresses it forever.
+
+Your browser already has this set:
+
+```js
+pizzaLogsFrozenIntroSeen = "1"
+```
+
+So normal live visits will not show it again. The replay link works because I added `?intro=1` as an override after your feedback.
+
+To test it like a brand-new user, use either:
+
+```js
+localStorage.removeItem("pizzaLogsFrozenIntroSeen")
+location.reload()
+```
+
+or open the site in an incognito/private window.
+
+The original requirement was â€œfirst visit per browser,â€ so I did not make it show every visit. But based on your reaction, the better UX may be to add a small, non-annoying replay control somewhere admin-facing or footer-level, or make it show once per deploy/version instead of once forever.
+
+## User
+
+lets make it slightly longer and use it for every page change always (not just once)
+
+## Assistant
+
+Implemented and pushed to `origin/main`.
+
+The Frozen Logbook intro now:
+- shows on initial load and every client-side page change
+- lasts `3000ms` instead of `2300ms`
+- still has `Skip`
+- no longer uses `localStorage`, so `pizzaLogsFrozenIntroSeen` will not suppress it anymore
+- keeps reduced-motion users on the short/simple version
+
+Validation:
+- `tests/frozen-intro-source.test.ts` passed after failing on the old behavior
+- `tests/ui-animation.test.ts` passed
+- TypeScript, ESLint, `next build`, `git diff --check` passed
+- Parser suite passed: `123 passed`
+- Local built-app browser check returned `initialIntro: true` and `routeChangeIntro: true`
+- Production bundle now has the route-change intro markers and no old `pizzaLogsFrozenIntroSeen` gate
+
+Commits pushed:
+- `a499de0 fix: replay frozen intro on route changes`
+- `3156eb8 docs: record route intro deployment`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - add-upload-cinematic-intro.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - add-upload-cinematic-intro.md
@@ -1,0 +1,563 @@
+# Add upload cinematic intro
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-04
+- Thread id: `019df16e-d28d-72c0-8581-ad7788a29250`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\04\rollout-2026-05-04T02-21-05-019df16e-d28d-72c0-8581-ad7788a29250.jsonl`
+- Imported user turns: 11
+- Imported assistant final replies: 10
+- Tool/command events omitted: 434
+
+## Discussion Digest
+
+## User
+
+[@superpowers](plugin://superpowers@openai-curated)
+
+You are working in my Pizza Logs codebase.
+
+Goal:
+Create a new upload-page-only cinematic intro animation inspired by the Lich King / Icecrown theme, while staying within the existing Pizza Logs branding and avoiding copyrighted assets.
+
+Animation concept:
+When the user navigates to the Upload page, play a short cinematic overlay:
+
+Scene:
+- A Codex-designed, original dark fantasy â€œfrozen kingâ€ figure walks away from the viewer across a frozen tundra in whiteout conditions.
+- The environment should feel like Icecrown / Northrend: snow, fog, ice, cold wind, dark blue-white atmosphere.
+- The figure abruptly stops and turns toward the viewer.
+- His eyes briefly glow as if he has locked aggro onto the viewer.
+- He swings an original rune-blade toward the screen.
+- The impact causes the screen/page overlay to tear, crack, or shatter open.
+- The normal Upload page is revealed underneath.
+
+Important legal/style constraint:
+- Do not use the actual Lich King model, Frostmourne model, Blizzard art, Warcraft assets, copyrighted silhouettes, logos, music, or sound effects.
+- Create an original â€œfrozen warlord / raid bossâ€ visual language that is clearly inspired by dark frozen fantasy but not copied from Blizzard.
+- Use CSS/SVG/canvas-generated visuals only unless the repo already has safe internal assets.
+- No external copyrighted image dependencies.
+
+Where it should play:
+- Only on the Upload page.
+- Plays every time the user navigates to the Upload page.
+- Must not play globally.
+- Must not block the site if animation fails.
+- Must have a visible Skip button.
+- Max duration: 3.5â€“4 seconds.
+- After completion or skip, fully unmount the overlay.
+
+Implementation approach:
+- First inspect the repo structure before making changes.
+- Find the Upload page route/component.
+- Add a reusable upload cinematic overlay component, for example:
+  - `UploadCinematicIntro`
+  - `FrozenAggroIntro`
+  - or a naming pattern that fits the repo.
+- Prefer CSS animations and lightweight SVG/canvas effects.
+- Use existing dependencies only.
+- If `framer-motion` already exists, it may be used.
+- If not, do not add it unless absolutely justified.
+- Do not add Three.js, WebGL, video files, audio, or large animation libraries for this MVP.
+
+Suggested animation structure:
+1. Overlay enters
+   - Full-screen fixed overlay above Upload page
+   - Existing Pizza Logs dark styling
+   - Snow/whiteout particle layer
+   - Frosted vignette around edges
+
+2. Figure walking away
+   - Original stylized silhouette or CSS/SVG figure
+   - Small, distant center-frame character moving slowly away
+   - Whiteout fog partially obscures the figure
+
+3. Aggro turn
+   - Figure stops abruptly
+   - Shoulders/helmet silhouette rotates or snaps toward viewer
+   - Eyes flash/glow briefly
+
+4. Blade swing
+   - Original rune-blade arc sweeps toward screen
+   - Use motion blur / slash trail / frost glow
+   - No actual Frostmourne design
+
+5. Page tear reveal
+   - Overlay cracks, tears, or splits open
+   - Upload page becomes visible underneath
+   - End by unmounting overlay
+
+Brand/style constraint:
+All visuals must stay within the current Pizza Logs design system:
+- existing colors
+- existing dark theme
+- existing button/card styling
+- existing spacing and typography
+- existing WoW-inspired but tool-first tone
+
+The animation should feel like an enhancement to Pizza Logs, not a full redesign or unrelated fan-site intro.
+
+Accessibility/performance requirements:
+- Respect `prefers-reduced-motion`.
+  - For reduced-motion users, show a simple fast frost fade/reveal instead of the full cinematic.
+- Do not cause layout shift.
+- Do not delay Upload page data loading.
+- Do not interfere with forms, upload state, drag/drop zones, or page hydration.
+- Overlay must be keyboard-safe.
+- Skip button must be focusable and work immediately.
+- Escape key should also skip the animation if easy.
+- Avoid heavy CPU/GPU usage.
+
+State behavior:
+- Unlike the homepage intro, this Upload page intro should play every visit to the Upload route.
+- Do not use localStorage to suppress it unless there is already a user-facing animation preference.
+- If there is already a reduced-animation preference in the app, respect it.
+
+Testing:
+Run all available validation commands in `package.json`, such as:
+- lint
+- typecheck
+- test
+- build
+
+Manual verification:
+- Navigate to Upload page and confirm intro plays.
+- Refresh Upload page and confirm intro plays again.
+- Click Skip and confirm Upload page is usable.
+- Press Escape and confirm intro skips if implemented.
+- Confirm reduced-motion mode avoids the full cinematic.
+- Confirm other pages do not show this animation.
+- Confirm mobile layout does not break.
+- Confirm upload functionality still works.
+- Confirm no copyrighted assets were introduced.
+
+Deliverables:
+- Implement the Upload page cinematic MVP.
+- Summarize changed files.
+- Explain how the animation is triggered.
+- Explain how to disable/remove it if
+
+[Truncated for vault import.]
+
+## Assistant
+
+Implemented, committed, and pushed branch `codex/upload-cinematic-intro` at `6f40661`.
+
+Changed:
+- Added [UploadCinematicIntro.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/intro/UploadCinematicIntro.tsx>)
+- Mounted it only from [app/page.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/page.tsx>)
+- Removed the global layout intro from [app/layout.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/layout.tsx>)
+- Replaced the old global intro CSS with upload cinematic CSS in [globals.css](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/globals.css>)
+- Updated source coverage in [frozen-intro-source.test.ts](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/frozen-intro-source.test.ts>)
+- Updated the required vault handoff/current/known-issues docs
+
+Trigger behavior: the Upload nav currently points to `/`, so the intro plays when that route mounts. It uses no `localStorage`, so refreshes and revisits play again. Other routes do not mount it.
+
+Disable/remove path: remove `<UploadCinematicIntro />` from `app/page.tsx`; then delete the component and the `.frozen-aggro-*` CSS/test assertions.
+
+Verified:
+- Red/green focused intro source test
+- `tsc --noEmit`
+- ESLint
+- all 27 standalone TS tests
+- `git diff --check`
+- `next build`
+- Chrome CDP against compiled app: skip, Escape, revisit/reload replay, reduced motion, mobile, non-upload absence, upload controls still usable
+
+Assumption: â€œUpload pageâ€ means the existing public Upload route `/`; `/uploads` is an admin redirect in this repo.
+
+::git-create-branch{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+show me it
+
+## Assistant
+
+Opened it locally in Chrome:
+
+[http://127.0.0.1:3007](http://127.0.0.1:3007)
+
+Refresh the page to replay it.
+
+Start beat:
+![Upload cinematic start](C:\Users\neil_\AppData\Local\Temp\pizza-upload-intro-live-start.png)
+
+Impact beat:
+![Upload cinematic impact](C:\Users\neil_\AppData\Local\Temp\pizza-upload-intro-live-impact.png)
+
+## User
+
+needs to be more cinematic and more like fan art
+
+## Assistant
+
+Implemented the more cinematic pass and pushed it.
+
+Preview is running here: [http://127.0.0.1:3007](http://127.0.0.1:3007)
+
+![Approach frame](/C:/Users/neil_/AppData/Local/Temp/pizza-upload-intro-final-approach.png)
+
+![Aggro frame](/C:/Users/neil_/AppData/Local/Temp/pizza-upload-intro-final-boss.png)
+
+![Impact frame](/C:/Users/neil_/AppData/Local/Temp/pizza-upload-intro-final-impact.png)
+
+Changed:
+- [UploadCinematicIntro.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/components/intro/UploadCinematicIntro.tsx>) now portals to `document.body`, so it covers the sticky header and keeps `Skip` visible.
+- [globals.css](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/globals.css>) has the larger original frozen warlord, ice spires, frost-fire, camera push, aggro detail reveal, blade swing, and crack impact.
+- [frozen-intro-source.test.ts](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/frozen-intro-source.test.ts>) covers the stronger cinematic classes and portal behavior.
+- Vault handoff/current/known-issues files were updated.
+
+Trigger/removal:
+- It still triggers only from the Upload page via `<UploadCinematicIntro />` in [app/page.tsx](</C:/Users/neil_/OneDrive/Desktop/PizzaLogs/app/page.tsx>).
+- To disable it, remove that component from `app/page.tsx`. To keep the component but suppress playback, guard that mount behind a feature flag/preference.
+
+Validation:
+- ESLint passed.
+- TypeScript passed.
+- Standalone TS tests passed `27/27`.
+- `git diff --check` passed.
+- `next build` passed from the main checkout.
+- Browser/CDP verified upload-only playback, refresh replay, Skip, Escape, reduced motion, mobile no-overflow, and upload input usability after skip.
+
+Committed and pushed:
+- `24db6a7 feat: make upload intro more cinematic`
+- Branch: `codex/upload-cinematic-intro`
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+show me the animation please
+
+## Assistant
+
+Hereâ€™s the animated preview:
+
+![Upload cinematic animation](/C:/Users/neil_/AppData/Local/Temp/pizza-upload-intro-animation.gif)
+
+Live preview is still running at [http://127.0.0.1:3007](http://127.0.0.1:3007).
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3007/
+
+## My request for Codex:
+that image isnt a blizzard asset please use it your lichking blockfigure is terrible
+
+## Assistant
+
+I rebuilt the warlord art instead of using the old blocky figure. It is still original SVG/CSS, but now has heavier armor, jagged crown, mask plates, cloak layers, fur/ice mantle, rune veins, and a rougher painted edge.
+
+![Updated upload cinematic](/C:/Users/neil_/AppData/Local/Temp/pizza-upload-intro-painted-animation.gif)
+
+Live preview is still running: [http://127.0.0.1:3007](http://127.0.0.1:3007)
+
+Pushed:
+`b89622f feat: refine upload intro warlord art`
+
+Validation passed: source test, TypeScript, ESLint, full TS suite `27/27`, `next build`, and browser/CDP checks. I left the unrelated `.obsidian/workspace.json` UI-state change unstaged.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+# In app browser:
+- The user has the in-app browser open.
+- Current URL: http://127.0.0.1:3007/
+
+## My request for Codex:
+i still want it more relistic more like a movie
+
+## Assistant
+
+Pushed the more movie-style pass to `origin/codex/upload-cinematic-intro` at `6482e4c`.
+
+![Upload cinematic animated preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-upload-cinematic-capture/upload-cinematic-preview.svg)
+
+Filmstrip preview:
+
+![Upload cinematic filmstrip](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-upload-cinematic-capture/upload-cinematic-filmstrip.png)
+
+Changed: added procedural film grain, letterbox bars, rolling fog, stronger backlight/visor glow, and adjusted the camera push so the face reads before the shatter. Still CSS/SVG-only, no external image asset.
+
+Validation passed: source test, type-check, ESLint, 27/27 TS tests, `next build`, `git diff --check`, and Chrome/CDP checks for Skip, Escape, refresh replay, reduced motion, mobile, and non-upload routes. Browser/IAB was blocked by Windows access denied, so I used CDP fallback. Local preview is still running at `http://127.0.0.1:3007/`.
+
+Unstaged: your existing `.obsidian/workspace.json`, plus temp preview/server logs.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+Attached is a completely AI genreated Image strip. no copywrite.
+
+Create a cinematic storyboard sequence for a web intro animation (film strip style, 30â€“36 frames).
+
+Constraints:
+- Original character design (DO NOT replicate any copyrighted IP)
+- Frost-themed armored dark king archetype
+- Environment: frozen tundra, whiteout snowstorm
+- Style: realistic cinematic, cold blue/gray palette
+
+Sequence requirements:
+- Frame-by-frame progression (each frame = a micro-action)
+- Maintain consistent character identity across frames
+- Use camera techniques: wide, medium, close-up, POV, tracking
+- Include environmental motion (snow, wind, particles)
+- Include lighting progression (low visibility â†’ glowing eyes â†’ energy burst)
+
+Key beats:
+1. Walking away in blizzard
+2. Pause + awareness trigger
+3. Slow turn toward viewer
+4. Eye glow activation (non-specific cyan energy)
+5. Aggressive lock-on stance
+6. Weapon summon (original frost blade, not Frostmourne)
+7. Swing toward camera
+8. Screen fracture (glass/ice effect)
+9. Tear transition into website UI
+10. Smooth blend into upload page
+
+Output format:
+- JSON array of frames
+- Each frame includes:
+  - frame_number
+  - camera_type
+  - description
+  - motion
+  - lighting
+  - transition_hint
+
+Animation notes:
+- Designed for web playback (Canvas/WebGL/Three.js compatible)
+- Smooth interpolation between frames
+- Loop disabled (plays on page load)
+- Duration target: 4â€“6 seconds total
+
+Avoid:
+- Direct references to Warcraft, Lich King, Frostmourne, or Blizzard IP
+- Trademarked symbols or armor likeness
+
+## Assistant
+
+[
+  {
+    "frame_number": 1,
+    "camera_type": "wide establishing",
+    "description": "Frozen tundra in near-whiteout. A faint dark figure is barely visible far ahead, walking away from the viewer.",
+    "motion": "Snow streaks diagonally across frame; cloak silhouette sways subtly in the wind.",
+    "lighting": "Low visibility, diffuse blue-gray daylight, no eye glow yet.",
+    "transition_hint": "Fade in from black with heavy snow opacity."
+  },
+  {
+    "frame_number": 2,
+    "camera_type": "wide tracking",
+    "description": "Camera pushes forward through drifting snow toward the lone armored king figure.",
+    "motion": "Slow forward dolly; snow particles pass close to lens.",
+    "lighting": "Cold ambient light, faint rim light around armor edges.",
+    "transition_hint": "Interpolate camera z-position forward."
+  },
+  {
+    "frame_number": 3,
+    "camera_type": "medium rear",
+    "description": "The figure becomes clearer: jagged original crown, layered dark armor, torn frost-heavy cloak.",
+    "motion": "Heavy footstep presses into ice; cloak drags and snaps in wind.",
+    "lighting": "Muted cyan bounce from icy ground.",
+    "transition_hint": "Increase character contrast as fog thins briefly."
+  },
+  {
+    "frame_number": 4,
+    "camera_type": "rear low angle",
+    "description": "Camera lowers behind him, emphasizing scale and weight as he walks into the storm.",
+    "motion": "Slow shoulder sway; snow trails around armor plates.",
+    "lighting": "Backlit haze outlines crown points and pauldrons.",
+    "transition_hint": "Ease camera downward and closer."
+  },
+  {
+    "frame_number": 5,
+    "camera_type": "medium rear close",
+    "description": "The armored king slows. His right hand hangs near an empty frost-lit space where a weapon will form.",
+    "motion": "Stride shortens; wind gust pushes cloak sideways.",
+    "lighting": "Subtle cyan pulse under the hand, almost hidden by snow.",
+    "transition_hint": "Begin reducing walking motion amplitude."
+  },
+  {
+    "frame_number": 6,
+    "camera_type": "over-shoulder rear",
+    "description": "He stops completely. Snow continues moving while the character becomes unnaturally still.",
+    "motion": "Foot plants; cloak settles, then flicks sharply in wind.",
+    "lighting": "Ambient dims slightly, isolating the silhouette.",
+    "transition_hint": "Hard ease-out on character movement."
+  },
+  {
+    "frame_number": 7,
+    "camera_type": "medium rear",
+    "description": "A subtle awareness trigger: the head tilts a few degrees as if hearing the viewer.",
+    "motion": "Tiny helmet movement; nearby snow swirls into a circular eddy.",
+    "lighting": "First faint cyan glimmer appears beneath visor slits.",
+    "transition_hint": "Hold for tension before turn."
+  },
+  {
+    "frame_number": 8,
+    "camera_type": "medium side tracking",
+    "description": "Camera begins to arc around his left shoulder as the figure starts turning.",
+    "motion": "Slow torso rotation; armor plates shift with heavy inertia.",
+    "lighting": "Cyan glimmer strengthens but remains partially obscured.",
+    "transition_hint": "Start orbit camera path around character."
+  },
+  {
+    "frame_number": 9,
+    "camera_type": "medium side",
+    "description": "Half-profile reveal: crown silhouette, mask-like helm, and layered shoulder armor cut through the storm.",
+    "motion": "Snow wraps around him in spiraling gusts.",
+    "lighting": "Rim light intensifies along helmet and cloak edges.",
+    "transition_hint": "Blend fog density down for clearer profile."
+  },
+  {
+    "frame_number": 10,
+    "camera_type": "medium three-quarter",
+    "description": "He turns further toward the viewer. The face remains mostly shadowed.",
+    "motion": "Cloak swings with delayed weight after the turn.",
+    "lighting": "Cyan eye glow flickers once, then fades.",
+    "transition_hint": "Use brief light flash synced to head turn."
+  },
+  {
+    "frame_number": 11,
+    "camera_type": "medium close-up",
+    "description": "The figure locks his shoulders square to camera. His posture becomes predatory and deliberate.",
+    "motion": "Snow blast crosses foreground; character stays still.",
+    "lighting": "Eye glow returns as two narrow cyan slits.",
+    "transition_hint": "Stabilize camera, reduce shake for lock-on beat."
+  },
+  {
+    "frame_number": 12,
+    "camera_type": "wide frontal",
+    "description": "Full frontal reveal in the whiteout: original frost king silhouette, broad armor, torn cloak, empty weapon hand.",
+    "motion": "Wind intensifies; ground snow sheets across his boots.",
+    "lighting": "Cyan eyes now visible from distance.",
+    "transition_hint": "Pull back slightly to show full stance."
+  },
+  {
+    "frame_number": 13,
+    "camera_type": "medium close-up",
+    "description": "Helmet detail fills more of the frame: no symbols, only original angular frost-metal design.",
+    "motion": "Fine ice particles drift past visor.",
+    "lighting": "Eyes glow brighter, casting cyan highlights on cheek plates.",
+    "transition_hint": "Slow push-in toward face."
+  },
+  {
+    "frame_number": 14,
+    "camera_type": "close-up",
+    "description": "Eye glow activates fully, non-specific cyan energy blooming behind the mask.",
+    "motion": "Snow near the face evaporates into sparkling frost mist.",
+    "lighting": "Cyan light spills onto crown edges and collar armor.",
+    "transition_hint": "Animate glow intensity from low to high."
+  },
+  {
+    "frame_number": 15,
+    "camera_type": "extreme close-up",
+    "description": "The visor dominates the frame. The eyes snap into a focused, aggressive lock-on.",
+    "motion": "Micro camera tremor; snow briefly slows as if suspended.",
+    "lighting": "Bright cyan core with soft bloom and lens haze.",
+    "transition_hint": "Short hold, then quick cut."
+  },
+  {
+    "frame_number": 16,
+    "camera_type": "medium frontal",
+    "description": "He lowers his stance and reaches one hand outward, preparing to summon a weapon.",
+    "motion": "Gauntlet opens; snow spirals toward his palm.",
+    "lighting": "Energy gathers in hand and along armor seams.",
+    "transition_hint": "Begin particle convergence toward hand."
+  },
+  {
+    "frame_number": 17,
+    "camera_type": "close-up hand",
+    "description": "Frost crystals assemble into the first outline of an original blade hilt.",
+    "motion": "Ice shards rotate and lock together piece by piece.",
+    "lighting": "Cyan-white flashes inside forming metal.",
+    "transition_hint": "Use procedural particles snapping to blade path."
+  },
+  {
+    "frame_number": 18,
+    "camera_type": "medium low angle",
+    "description": "The frost blade extends downward, jagged but original, with simple glowing glyph cuts.",
+    "motion": "Blade grows from hilt; frost vapor pours off the edge.",
+    "lighting": "Weapon becomes primary light source.",
+    "transition_hint": "Interpolate blade scale and opacity upward."
+  },
+  {
+    "frame_number": 19,
+    "camera_type": "medium frontal"
+
+[Truncated for vault import.]
+
+## User
+
+still working?
+
+## Assistant
+
+Iâ€™m here. No background job is running right now.
+
+Last completed work: the movie-style upload intro was committed and pushed on `codex/upload-cinematic-intro`. The storyboard JSON I just gave is not yet implemented into the app. Next step is turning that 36-frame sequence into the actual Upload intro animation.
+
+## User
+
+do it
+
+## User
+
+undo everything in this chat.
+
+## Assistant
+
+I found the chatâ€™s changes:
+
+- Uncommitted storyboard attempt:
+  - `app/globals.css`
+  - `components/intro/UploadCinematicIntro.tsx`
+  - `tests/frozen-intro-source.test.ts`
+  - new `lib/upload-cinematic-storyboard.ts`
+  - new `tests/upload-cinematic-storyboard.test.ts`
+  - temp preview/server files
+- Pushed branch commits to undo:
+  - `6482e4c`
+  - `b89622f`
+  - `24db6a7`
+  - `6f40661`
+- Local preview server is still running on `127.0.0.1:3007`.
+
+Confirm you want me to proceed with the undo by discarding/deleting those local files and reverting the four pushed commits on `codex/upload-cinematic-intro`, then pushing the undo commit(s) to GitHub.
+
+## User
+
+yes
+
+## Assistant
+
+Undo is complete and pushed.
+
+I reverted the cinematic work from commits `6482e4c`, `b89622f`, `24db6a7`, and `6f40661` with revert commit `6abe45d`, then pushed it to `origin/codex/upload-cinematic-intro`.
+
+Validation passed before the revert commit:
+`type-check`, ESLint, TS test sweep `27/27`, production build, and `git diff --cached --check`.
+
+I also removed the uncommitted storyboard/temp files and stopped the local preview server on port `3007`. The only remaining local change is unrelated: `Pizza Logs HQ/.obsidian/workspace.json`.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex/upload-cinematic-intro"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - create-cinematic-landing-animation.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - create-cinematic-landing-animation.md
@@ -1,0 +1,664 @@
+# Create cinematic landing animation
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-04
+- Thread id: `019df33e-173e-7561-b335-23eefac9b0a0`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\04\rollout-2026-05-04T10-47-06-019df33e-173e-7561-b335-23eefac9b0a0.jsonl`
+- Imported user turns: 25
+- Imported assistant final replies: 25
+- Tool/command events omitted: 751
+
+## Discussion Digest
+
+## User
+
+attached is an a strip of images i want to be recreated into a cinimatic animation when yours land on my page. provide me the animation output so i can approve the work before commiting and changes to the codebase
+
+## Assistant
+
+Created an approval-only preview. No commit, no app source changes, and the existing `.obsidian/workspace.json` change was left untouched.
+
+![Cinematic upload intro preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/upload-cinematic-preview.gif)
+
+Preview files:
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-preview.gif`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-contact-sheet.png`
+
+Motion beats: blizzard approach, armored frost boss close-up, blue eye reveal, sword slash, ice crack/shatter, then the Pizza Logs upload page reveal. Send approval or the exact beats you want changed before I touch the codebase.
+
+## User
+
+use the generated images I provided please
+
+## Assistant
+
+Agreed. I should use your 36 generated panels directly.
+
+I canâ€™t access the chat attachment as a local image file from the repo tools. Save the strip somewhere in the workspace, for example:
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\cinematic-strip.png`
+
+Then tell me the path. Iâ€™ll slice the 6x6 grid into frames, build the animation preview from those exact images, and still wonâ€™t commit anything until you approve.
+
+## User
+
+there its in the tmp-mobile-check folder
+
+## Assistant
+
+Rendered from your supplied strip, not from scratch. I sliced the detected 6x6 grid, removed the frame numbers, and built an approval animation.
+
+![Upload cinematic from strip](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/upload-cinematic-from-strip.webp)
+
+Files:
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-from-strip.webp`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-from-strip.gif`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-from-strip-contact-sheet.png`
+
+No code changes or commits made. Current git status only shows the pre-existing `.obsidian/workspace.json` change.
+
+## User
+
+can you genreating more frames inbetween to make it more fluid and cut it off before it goes into an image of the actual website since that was just a brainstorm mock and isnt my actual site in the final few frames
+
+## Assistant
+
+Done. I rebuilt it from your supplied strip using panels `1-32` only, so it stops before the brainstorm website mock frames. I also increased it to `364` rendered frames for smoother interpolation.
+
+![Fluid cinematic preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/upload-cinematic-fluid-no-site.webp)
+
+Files:
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-fluid-no-site.webp`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-fluid-no-site.gif`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-fluid-no-site-motion-sheet.png`
+
+No code changes or commits made. The only git change is still the pre-existing `.obsidian/workspace.json`.
+
+## User
+
+this needs to be high def, and more fluid. this is the intro screen for my website. lets make this as professional as we can get it
+
+## Assistant
+
+Rendered a higher-end master from your strip:
+
+![HD cinematic intro](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/upload-cinematic-pro-hd-no-site.mp4)
+
+Output:
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-pro-hd-no-site.mp4`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-pro-hd-no-site.webm`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\upload-cinematic-pro-hd-no-site-motion-sheet.jpg`
+
+Specs: `1920x1080`, `60fps`, `12.8s`, panels `1-32` only, no brainstorm website mock frames. It now ends with a dark fade so the real site can appear underneath when implemented.
+
+No repo code changes or commits. Only the pre-existing `.obsidian/workspace.json` git change remains.
+
+## User
+
+You are rebuilding the intro animation pipeline from scratch.
+
+The previous implementation is unacceptable. Do not reuse, adapt, or reference any prior animation logic, assets, or timing. Start clean.
+
+-------------------------------------
+INPUT
+-------------------------------------
+Reference image:
+- File: "new image frames.png"
+- Location: /tmp-mobile-check/
+
+This image is a film strip containing sequential animation frames.
+It is the ONLY source of truth.
+
+-------------------------------------
+OBJECTIVE
+-------------------------------------
+Create a smooth 4-second, 60 FPS cinematic intro animation using this image.
+
+-------------------------------------
+CORE REQUIREMENTS
+-------------------------------------
+
+1. FRAME EXTRACTION
+- Programmatically detect grid layout (rows/columns)
+- Slice into uniform frames
+- Read left-to-right, top-to-bottom
+- Export sequentially:
+  frame_0001.png â†’ frame_N.png
+- Ensure identical resolution for all frames
+
+2. FRAME NORMALIZATION
+- Normalize to consistent dimensions (target 1920x1080 or proportional upscale)
+- Preserve aspect ratio (no stretching)
+- Apply padding if required
+
+3. TIMING
+- Total duration: 4 seconds
+- Target: 60 FPS (240 frames)
+
+IF frames < 240:
+- Evenly distribute timing
+- Apply interpolation (preferred) OR intelligent duplication
+
+IF frames > 240:
+- Evenly downsample without breaking motion continuity
+
+4. SMOOTHING (IMPORTANT)
+- Implement interpolation (optical flow / blending)
+- Reduce AI jitter between frames
+- Ensure motion feels continuous
+
+-------------------------------------
+RENDER OUTPUT (REVIEW-ONLY)
+-------------------------------------
+- Generate a FINAL animation output:
+  - intro_preview.mp4 OR intro_preview.webm
+  - 60 FPS
+  - 1920x1080
+- This is REQUIRED for review
+
+-------------------------------------
+ISOLATION (CRITICAL)
+-------------------------------------
+- DO NOT modify any existing project files
+- DO NOT integrate into the website
+- DO NOT replace any current animation
+- All work must be isolated
+
+-------------------------------------
+OUTPUT LOCATION
+-------------------------------------
+Create:
+/tmp-mobile-check/animation_preview/
+
+Place inside:
+- Extracted frames
+- Any intermediate processed frames
+- Final compiled animation file
+- Script(s) used for slicing + rendering
+
+-------------------------------------
+RENDER BEHAVIOR
+-------------------------------------
+- Natural cinematic pacing
+- No UI elements
+- No overlays
+- Clean ending (soft fade or hold final frame)
+
+-------------------------------------
+FAIL CONDITIONS
+-------------------------------------
+- Using previous animation logic
+- Hardcoding frame counts
+- Skipping interpolation
+- Modifying anything outside /tmp-mobile-check/
+- Not producing a playable animation file
+
+-------------------------------------
+DELIVERABLE
+-------------------------------------
+A fully playable animation file generated from:
+"/tmp-mobile-check/new image frames.png"
+
+Saved to:
+"/tmp-mobile-check/animation_preview/"
+
+No integration. No side effects. Review-only output.
+
+## Assistant
+
+Built the fresh isolated preview pipeline under:
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\animation_preview`
+
+![Intro preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/animation_preview/intro_preview.mp4)
+
+Outputs:
+- `intro_preview.mp4` - 1920x1080, 60 FPS, 4.0s
+- `intro_preview.webm`
+- `extracted_frames/frame_0001.png` through `frame_0054.png`
+- `processed_frames/frame_0001.png` through `frame_0240.png`
+- `render_intro_preview.py`
+- `render_metadata.json`
+- `source_strip.png`
+
+Verification:
+- Detected grid: `9x6`
+- Extracted frames: `54`
+- Processed frames: `240`
+- Processed frame size: `1920x1080`
+- No project files changed, no integration, no commit.
+
+Note: the exact file `new image frames.png` was not present; the folder had `new intro frames.png`, so that was used as the source and copied into the preview package as `source_strip.png`.
+
+## User
+
+is that preview how it would look on the site?
+
+## Assistant
+
+Not exactly.
+
+That preview is the rendered animation asset. On the site, it would depend on how we mount it:
+
+- `object-fit: contain` would look very close to the preview, including the side padding/letterbox.
+- `object-fit: cover` would feel more like a full-screen cinematic intro, but it would crop some of the top/bottom or sides.
+- The final site version would also need the real fade-out behavior into the current Pizza Logs page underneath.
+
+So: the motion and frame quality are representative, but the actual on-site presentation still needs a browser overlay preview before approval. Iâ€™d treat the current file as the animation master, not the final site look.
+
+## User
+
+ok because it looks like something from the 90s... anyway we can take this as a proof of concept and actually make a true highdef 3d rendering of it to be more modering and actually look good? [$superpowers:brainstorming](C:\\Users\\neil_\\.codex\\plugins\\cache\\openai-curated\\superpowers\\3c463363\\skills\\brainstorming\\SKILL.md)
+
+## User
+
+sure
+
+## Assistant
+
+The low-quality look is mainly because the strip frames are tiny and we were upscaling storyboard stills into HD. For a professional intro, we should stop treating those frames as final pixels and use them only as art direction.
+
+One key direction question: should the final intro be a **pre-rendered cinematic video** that plays over the site, or a **live 3D/WebGL scene** rendered in the browser?
+
+My default recommendation is pre-rendered video for quality: it can look far more polished, loads predictably, and fades into the real page cleanly. Live 3D is more interactive/editable but much harder to make look premium without hurting performance.
+
+## User
+
+ok but so far with videos it looks like something from the 90s... anyway we can take this as a proof of concept and actually make a true highdef 3d rendering of it to be more modering and actually look good?
+
+## Assistant
+
+Yes. The right move is to stop using the strip as production footage. Use it only as a storyboard: snowfield approach, armored king turn, blue-eye reveal, close-up, final ominous hold.
+
+A true modern version would be built from new HD 3D/AI-rendered source shots, then edited into a clean 4-6 second intro. The final website should play a polished compressed video/WebM overlay, not try to upscale low-res storyboard frames.
+
+One question first: do you want the final style to be closer to **cinematic Warcraft/ICC realism** or **dark premium app intro with fantasy influence**?
+
+My read is: cinematic Warcraft/ICC realism, but restrained enough that it still feels like a polished web product intro rather than a game trailer.
+
+## User
+
+yes you read is correct
+
+## Assistant
+
+Good. Then Iâ€™d frame the options like this:
+
+**Recommended: Pre-rendered HD Cinematic**
+Generate a small set of true HD cinematic shots from the storyboard, then assemble them into a 4-5s 60fps WebM/MP4 intro. This gives the best visual quality and the most reliable website performance. The site just plays the video fullscreen, fades it out, and reveals Pizza Logs underneath.
+
+**Alternative: Live Three.js Scene**
+Build an in-browser 3D scene with snow, fog, camera push, and a stylized armored silhouette. More dynamic, but much harder to make AAA-looking without real models, textures, animation rigs, and performance tuning. It risks looking â€œweb demoâ€ instead of premium.
+
+**Heavyweight: Blender/True 3D Production Pipeline**
+Use actual modeled assets, rigging, lighting, particles, and offline rendering. Highest ceiling, but slowest and most expensive in time. Worth it only if you want a reusable trailer-grade asset pipeline, not just a site intro.
+
+My recommendation: **pre-rendered HD cinematic**, using the strip only as the storyboard. We generate or create 5-7 high-res key shots, keep the Lich King/ICC realism, then render an intro video that feels like a polished game launcher splash, not a low-res GIF.
+
+Design direction:
+- 4-5 seconds total.
+- Fullscreen cinematic overlay.
+- Snowfield approach, slow camera push.
+- Armored back/shoulder silhouette turns slightly.
+- Blue eyes ignite.
+- Close-up helmet moment.
+- Frost/snow wipe or dark fade into the real Pizza Logs page.
+- No visible text in the video unless we deliberately add a very subtle Pizza Logs mark after the cinematic moment.
+
+Does that direction sound right so far?
+
+## User
+
+yes
+
+## Assistant
+
+**Creative Treatment**
+
+We treat the strip as a storyboard, not as footage. The final intro should feel like a short ICC-style cinematic: a frost-armored raid boss emerging through a blizzard, camera pushing from distant snowfield to shoulder/back silhouette, then a controlled turn toward camera as blue eyes ignite. The last beat should be a high-impact close-up or frost-dark wipe, then fade into the real Pizza Logs page.
+
+No UI mock frames in the video. No old-school GIF feel. No obvious 2D slideshow. The animation should be built from high-resolution cinematic key shots with subtle 3D-like camera movement, depth, snow/fog layers, lighting, and motion blur. The website integration later should simply play the finished asset as a fullscreen intro overlay.
+
+Creative target: **Warcraft/ICC realism, modern web-product polish, dark frost atmosphere, premium not cheesy.**
+
+Does this creative treatment look right before I define the production pipeline?
+
+## User
+
+yes
+
+## Assistant
+
+**Production Pipeline**
+
+Use a new asset pipeline, not the frame-strip pipeline.
+
+1. **Storyboard Lock**
+   Use your strip only to define beats:
+   distant approach â†’ back/shoulder reveal â†’ turn â†’ blue eyes â†’ close-up â†’ frost/dark transition.
+
+2. **Generate HD Key Shots**
+   Create 5-7 high-resolution 16:9 cinematic shots from scratch:
+   original frost-armored raid boss, ICC/WotLK-inspired atmosphere, heavy snow, blue eye glow, premium lighting. Not a literal ripped game asset or exact copied character.
+
+3. **Animate With Cinematic Compositing**
+   Build motion from the HD shots using:
+   depth-style parallax, camera push, fog/snow layers, subtle cloth/armor movement illusion, eye-glow ramp, controlled motion blur, and a final frost/dark fade.
+
+4. **Render Web-Ready Master**
+   Output:
+   `intro.webm` for the site, `intro.mp4` fallback, poster frame, and a small review version.
+   Target: 4-5s, 1080p or 1440p source, optimized for fast page load.
+
+5. **Later Website Integration**
+   Fullscreen overlay, skip button, reduced-motion fallback, play once per visit or per route depending on final preference, fade into the actual Pizza Logs page.
+
+This keeps the final site intro looking like a modern cinematic asset while still being practical for a web app.
+
+Does this production pipeline look right?
+
+## User
+
+lets see build it
+
+## Assistant
+
+Spec written, self-reviewed, committed, and pushed on `codex/upload-cinematic-intro`.
+
+Review this file before I move into the implementation plan: [2026-05-04-hd-cinematic-intro-design.md](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/docs/superpowers/specs/2026-05-04-hd-cinematic-intro-design.md)
+
+Commit: `34628ad docs: add hd cinematic intro design`
+
+I left the pre-existing `.obsidian/workspace.json` change unstaged. Once you approve the spec, Iâ€™ll move to the implementation plan and then build the actual HD cinematic asset pipeline.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+let me see it. build it out and lets see what you can do
+
+## Assistant
+
+Built the isolated HD cinematic review cut.
+
+![HD cinematic intro review](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/rendered/intro_hd_cinematic_review.mp4)
+
+Fallback files:
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\hd_cinematic_intro\rendered\intro_hd_cinematic_review.mp4`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\hd_cinematic_intro\rendered\intro_hd_cinematic_review.webm`
+- `C:\Users\neil_\OneDrive\Desktop\PizzaLogs\tmp-mobile-check\hd_cinematic_intro\rendered\review_contact_sheet.jpg`
+
+Verified: `1920x1080`, `60fps`, `5.0s`, `300` rendered frames. No app integration or site code was changed; this is review-only. I committed and pushed only the plan/vault context. The existing `.obsidian/workspace.json` change remains unstaged.
+
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+can i see the rendering
+
+## Assistant
+
+Hereâ€™s the rendered preview:
+
+![HD cinematic intro review](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/rendered/intro_hd_cinematic_review.mp4)
+
+And the contact sheet:
+
+![HD cinematic intro contact sheet](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/rendered/review_contact_sheet.jpg)
+
+## User
+
+ok well lets see what you can do with it on my live webapp as an intro
+
+## Assistant
+
+Itâ€™s live on production now: [pizza-logs-production.up.railway.app](https://pizza-logs-production.up.railway.app/)
+
+Hard refresh the page to see the intro. It plays the HD cinematic on initial page load, has a `Skip` button, then fades into the actual app. It no longer replays on every internal route click.
+
+![Production intro screenshot](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/site_integration/production-intro-edge.png)
+
+![After intro reveal](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/site_integration/production-after-edge.png)
+
+Verified:
+- Production intro assets return `200`: WebM, MP4, poster.
+- Production layout bundle contains the new cinematic source and no old particle intro marker.
+- Focused intro test passed.
+- TypeScript, ESLint, `git diff --check`, temp-copy production build, and parser tests passed.
+- Main and feature branch both point to `eb584f9`.
+
+Only unrelated local dirt left is `Pizza Logs HQ/.obsidian/workspace.json`, still unstaged.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+not too bad can we increase the resolution and to make the image more crisp and can we add more frames or do whatever we can to make it less choppy and also change the aspect for mobile view port and fix the /bosses page for mobile as well with the same table animation styles on the other pages
+
+## Assistant
+
+Done and deployed.
+
+The intro is now sharper: desktop is `2560x1440`, mobile has its own `1080x1920` portrait render, both `60fps`, `5.2s`, `312` frames. The live app now selects mobile video/poster assets on narrow viewports. `/bosses` now uses mobile boss cards with the same reveal animation style as the other pages, while desktop keeps the table grid.
+
+![Desktop intro preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/public/intro/pizza-logs-cinematic-intro.webm)
+
+![Mobile intro preview](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/public/intro/pizza-logs-cinematic-intro-mobile.webm)
+
+![Production bosses mobile](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tmp-mobile-check/hd_cinematic_intro/site_integration/production-bosses-mobile-500-final.png)
+
+Verified:
+- Focused intro, bosses mobile, and UI animation tests passed.
+- Type-check, ESLint, `git diff --check`, temp production build passed.
+- Parser suite passed: `123 passed`.
+- Production assets returned HTTP 200 with expected byte sizes.
+- Live `/bosses` markup includes mobile/reveal/overflow guard markers.
+
+Pushed:
+- Code/assets commit: `0ad6231`
+- Docs verification commit: `7075c42`
+- Branch and `origin/main` are both pushed.
+- Only remaining local dirt is the pre-existing unstaged `Pizza Logs HQ/.obsidian/workspace.json`.
+
+Live:
+[https://pizza-logs-production.up.railway.app](https://pizza-logs-production.up.railway.app)
+[https://pizza-logs-production.up.railway.app/bosses](https://pizza-logs-production.up.railway.app/bosses)
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+anyway to create three more assets, 4k 9x16 for Mobile, keep the 1080p then scale 16x9 and auto detect 1440p and 4k as well
+
+## Assistant
+
+Implemented and deployed at `dd670a4`.
+
+Added the responsive intro asset ladder:
+- Desktop: `1920x1080`, existing `2560x1440`, new `3840x2160`
+- Mobile portrait: existing `1080x1920`, new `2160x3840`
+- WebM first, MP4 fallback, matching posters
+- Auto-selected through ordered `<source media>` rules so plain desktop falls back to 1080p, QHD/high-density gets 1440p, 4K/high-density gets 4K, and high-density mobile gets portrait 4K.
+
+Validated:
+- `tests/frozen-intro-source.test.ts` passed
+- all intro videos verified as `60fps`, `5.2s`, correct dimensions
+- TypeScript passed
+- ESLint passed
+- parser suite passed: `123 passed`
+- production build passed
+- production asset URLs returned HTTP 200 with expected byte lengths
+- production headless Edge confirmed the live hydrated intro has the full responsive source ladder
+
+Pushed to both `origin/codex/upload-cinematic-intro` and `origin/main`. The only remaining unstaged local change is the pre-existing `Pizza Logs HQ/.obsidian/workspace.json`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+its still too chopy. its needs more frames inbetween and its really grainy. i want the image to be more crisp!
+
+please note that the boss page fix is in and the responsiveness on mobile is good and I also want the tmp_mobile_check folder renamed to animiations and that anything inside the folder that is stale and unused be cleaned up
+
+## Assistant
+
+Implemented and pushed.
+
+The intro is now a smoother crisp ladder: `6.4s`, `60fps`, `384` frames across 1080p, 1440p, 4K, mobile 9:16, and mobile 4K. I reduced the choppy keyframe jumps, lowered snow/grain, sharpened/denoised the render, and updated the intro timeout to `6400ms`.
+
+I also renamed the local ignored render workspace from `tmp-mobile-check` to `animations` and cleaned stale previews, frame dumps, old render passes, logs, and old scripts. `/bosses` was left untouched since you said the mobile fix is good.
+
+Validation passed:
+- intro source test
+- media metadata: all videos `60fps`, `6.4s`, `384` frames
+- TypeScript
+- ESLint
+- parser suite: `123 passed`
+- production build
+- local public asset checks
+- production asset byte-length verification after Railway deploy
+
+Pushed to both `codex/upload-cinematic-intro` and `main`. Current pushed head is `459b352`. The only remaining local change is the pre-existing unstaged `Pizza Logs HQ/.obsidian/workspace.json`.
+
+The one real quality ceiling: the current key art is still lower-resolution than true native 4K, so this pass improves smoothness and grain, but the next jump in crispness would require regenerating the key shots at higher native resolution.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+it still has that blunt switching like there isn't enough stills between tell me if you understand
+
+## Assistant
+
+Yes, I understand.
+
+The problem is not â€œthe video file isnâ€™t 60fps.â€ It is that the animation is still built from too few real visual states. Even with 384 output frames, the subject is jumping between a small number of still images, so the viewer sees blunt pose/composition switches instead of continuous motion.
+
+The fix is a different pipeline:
+
+1. Generate or render many more true in-between boss frames, not just blend existing stills.
+2. Keep the camera, silhouette, armor shape, and face position consistent from frame to frame.
+3. Use optical-flow interpolation only between close neighboring frames, not between big composition changes.
+4. Then encode at 60fps after the motion is already smooth.
+
+So yes: I understand that the current issue is semantic frame continuity. More exported frames alone wonâ€™t fix it unless those frames are real intermediate poses.
+
+## User
+
+so can you do that?
+
+## Assistant
+
+Yes.
+
+But Iâ€™d do it as a new pass, not by tweaking the current renderer. The current source is too sparse, so the right fix is:
+
+1. Generate many more controlled intermediate boss frames.
+2. Keep the boss position/pose consistent across frames.
+3. Interpolate only between close neighboring frames.
+4. Render a review video first under `animations/`, before touching site assets.
+
+That should remove the blunt â€œcutâ€ feeling. The main constraint is quality of generated in-between frames: if they drift too much, Iâ€™ll need to reject/regenerate them rather than blend bad frames.
+
+## User
+
+Yes that's sounds better let's do that. that's is your goal. don't stop until you have a review video for me
+
+## Assistant
+
+Built the review video.
+
+![Continuity review video](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/animations/hd_cinematic_intro/continuity_review/intro_continuity_review.mp4)
+
+Contact sheet:
+
+![Continuity contact sheet](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/animations/hd_cinematic_intro/continuity_review/intro_continuity_review_contact_sheet.jpg)
+
+Output:
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs\animations\hd_cinematic_intro\continuity_review\intro_continuity_review.mp4`
+
+Specs:
+- `1920x1080`
+- `60fps`
+- `7.2s`
+- `432` frames
+- review-only, isolated under `animations/`
+- no site assets changed
+- no tracked repo files changed
+
+This pass hides the source still changes behind storm-wipe transitions and keeps camera motion continuous, so it should feel less like blunt still-to-still switching.
+
+## User
+
+better output it at 4k and then scale it down for the animation I think it will be cleaner that way and it should be scaled down for multiple viewports 9*16 & 16*9 plus multiple resolutions that trigger based on the user's montior size and device
+
+## Assistant
+
+Done. I rendered the responsive review ladder from 4K masters first, then downscaled.
+
+16:9 4K review:
+
+![16:9 4K review](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/animations/hd_cinematic_intro/continuity_review/responsive_4k_ladder_review/landscape_16x9/pizza-logs-cinematic-intro-4k.mp4)
+
+9:16 mobile 4K review:
+
+![9:16 mobile 4K review](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/animations/hd_cinematic_intro/continuity_review/responsive_4k_ladder_review/portrait_9x16/pizza-logs-cinematic-intro-mobile-4k.mp4)
+
+Generated review outputs:
+- `3840x2160` landscape 4K
+- `2560x1440` landscape downscale
+- `1920x1080` landscape downscale
+- `2160x3840` portrait/mobile 4K
+- `1080x1920` portrait/mobile downscale
+
+All are `60fps`, `7.2s`, `432` frames. The site already has the monitor/device source ladder logic; these files are named to map into that ladder after approval. I did not replace public site assets or commit anything. The only tracked local change remains the pre-existing `.obsidian/workspace.json`.
+
+## User
+
+well let's see what you can do with this. deploy it to my website
+
+## Assistant
+
+Deployed.
+
+The site is now using the 4K-master responsive intro ladder:
+- `3840x2160`, `2560x1440`, `1920x1080`
+- `2160x3840`, `1080x1920`
+- WebM first, MP4 fallback
+- `60fps`, `7.2s`, `432` frames
+- intro timeout updated to `7200ms`
+
+Validation passed:
+- intro source test
+- video/poster metadata checks
+- TypeScript
+- ESLint
+- `git diff --check`
+- parser suite: `123 passed`
+- production `next build`
+- local asset HTTP checks
+
+Pushed to `main` and verified production asset byte lengths on Railway. Current remote head is `ee09913`. The one remaining local change is the pre-existing unstaged `Pizza Logs HQ/.obsidian/workspace.json`.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex/upload-cinematic-intro"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - locate-duplicate-pizzalogs-folder.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - locate-duplicate-pizzalogs-folder.md
@@ -1,0 +1,157 @@
+# Locate duplicate PizzaLogs folder
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-04
+- Thread id: `019df116-c50c-7bc3-bc59-90a824973fc7`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\04\rollout-2026-05-04T00-44-54-019df116-c50c-7bc3-bc59-90a824973fc7.jsonl`
+- Imported user turns: 7
+- Imported assistant final replies: 7
+- Tool/command events omitted: 74
+
+## Discussion Digest
+
+## User
+
+I have two PizzaLogs folders on my desktop... the just plain PizzaLogs is my project folder. not entire sure where the other came from and if i can delete it
+
+## Assistant
+
+Yes, the other folder is safe to remove from a code/history standpoint.
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix` is a registered Git worktree, not a separate project. It is checked out on local `main`, has no uncommitted or untracked files, has no commits ahead of `origin/main`, and is 12 commits behind the current remote. The only local extras I found are generated/cache files like `.next/`, `node_modules/`, parser `__pycache__`, `.pytest_cache`, and `tsconfig.tsbuildinfo`.
+
+It most likely came from the earlier `main-queue-fix` worktree used during the Maxximusboom gear queue / modernization merge work.
+
+Best removal method:
+
+```powershell
+cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+& 'C:\Program Files\Git\cmd\git.exe' worktree remove 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix'
+```
+
+Do that instead of deleting it in Explorer, because Git will also clean up the `.git/worktrees/PizzaLogs-main-queue-fix` metadata. I did not delete anything yet.
+
+## User
+
+PS C:\WINDOWS\system32> cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+>> & 'C:\Program Files\Git\cmd\git.exe' worktree remove 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix'
+>>
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n) Y
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n) --FORCE
+Sorry, I did not understand your answer. Please type 'y' or 'n'
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n) y
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n)
+
+## Assistant
+
+Type `n` at that prompt to stop the stuck removal.
+
+Then run this as a fresh command:
+
+```powershell
+cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+& 'C:\Program Files\Git\cmd\git.exe' worktree remove --force 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix'
+```
+
+`--force` has to be part of the command, not typed as an answer to Gitâ€™s `y/n` retry prompt. If it still fails on `.claude`, tell me the next error and Iâ€™ll give you the cleanup command for the locked folder.
+
+## User
+
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n) y
+Deletion of directory 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix/.claude' failed. Should I try again? (y/n) n
+error: failed to delete 'C:/Users/neil_/OneDrive/Desktop/PizzaLogs-main-queue-fix': Permission denied
+Deletion of directory '.git/worktrees/PizzaLogs-main-queue-fix/logs' failed. Should I try again? (y/n) y
+Deletion of directory '.git/worktrees/PizzaLogs-main-queue-fix/logs' failed. Should I try again? (y/n) n
+error: failed to delete '.git/worktrees/PizzaLogs-main-queue-fix': Permission denied
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs> cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+>> & 'C:\Program Files\Git\cmd\git.exe' worktree remove --force 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix'
+>>
+fatal: 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix' is not a working tree
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs>
+
+## Assistant
+
+Cleaned it up.
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs-main-queue-fix` is gone, and the stale Git metadata at `.git\worktrees\PizzaLogs-main-queue-fix` is gone too. Your real project folder is still registered as the only worktree, and its `node_modules` folder is still intact.
+
+Current repo status is unchanged except for the pre-existing Obsidian UI files:
+
+```text
+M Pizza Logs HQ/.obsidian/graph.json
+M Pizza Logs HQ/.obsidian/workspace.json
+```
+
+## User
+
+just delete the folder if its safe to
+
+## Assistant
+
+Already done. The extra `PizzaLogs-main-queue-fix` folder was safe to delete, and I removed it plus the stale Git worktree metadata. Your real project folder `PizzaLogs` is untouched.
+
+## User
+
+ok also i dont want the branch i have currently i just want main
+
+## Assistant
+
+Done. Your PizzaLogs checkout is now on `main`, and the only local branch left is `main`.
+
+I removed the old local `codex/pizza-logs-modernization` branch and the three old merged `claude/...` local branches. I did not delete any remote GitHub branches.
+
+Only remaining local changes are the same Obsidian UI-state files:
+
+```text
+Pizza Logs HQ/.obsidian/graph.json
+Pizza Logs HQ/.obsidian/workspace.json
+```
+
+::git-create-branch{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}
+
+## User
+
+i meant the modernization branch as well. i just want the public main on git
+
+## Assistant
+
+Done. I deleted the public GitHub branch `codex/pizza-logs-modernization` and pruned local remote refs.
+
+Verified state now:
+
+```text
+local branches: main
+remote branches: origin/main
+```
+
+Your checkout is still on `main`, up to date with `origin/main`. The only local dirt remains the Obsidian UI-state files.
+
+## User
+
+osidian is my AI brain though. i like to keep it updateed in git as well
+
+## Assistant
+
+Understood, and thatâ€™s fixed now.
+
+I committed and pushed the Obsidian vault state plus a short handoff/Now note documenting the folder and branch cleanup:
+
+`d283367 docs: sync vault after branch cleanup`
+
+Current state:
+
+```text
+local branch: main
+remote branch: origin/main
+working tree: clean
+```
+
+No tests were run because this was vault/docs-only.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="main"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - set-up-test-server-correctly.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-04 - set-up-test-server-correctly.md
@@ -1,0 +1,1198 @@
+# Set up test server correctly
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-04
+- Thread id: `019df5dc-fde0-7c71-be82-9ff60b333c30`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\04\rollout-2026-05-04T22-59-54-019df5dc-fde0-7c71-be82-9ff60b333c30.jsonl`
+- Imported user turns: 33
+- Imported assistant final replies: 31
+- Tool/command events omitted: 759
+
+## Discussion Digest
+
+## User
+
+let set up my test server correctly
+
+## Assistant
+
+Test server is set up and left running:
+
+- App: `http://127.0.0.1:3001`
+- Parser: `http://127.0.0.1:8000`
+- Postgres: `localhost:5432`
+
+I stopped the stale local Next servers on `3000`, `3005`, and `3006`, cleared the generated `.next/` cache that was hitting the OneDrive `readlink` issue, then restarted the stack on the ports in `.env.local`.
+
+Validation passed: parser `/health` returned 200, the main pages and DB-backed APIs returned 200, and the app/admin pages are not showing database/parser outage warnings. Local DB is seeded with bosses/realms/items, but still has `0` players/uploads/encounters until you upload/import data.
+
+I updated the vault handoff files and pushed commit `843d290` to `codex/upload-cinematic-intro`. Existing `.obsidian/workspace.json` remains modified and unstaged.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+can you set this up so its always running even after reboots?
+
+## Assistant
+
+Set it up.
+
+I added repo scripts:
+
+- [start-local-test-server.ps1](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/scripts/start-local-test-server.ps1)
+- [stop-local-test-server.ps1](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/scripts/stop-local-test-server.ps1)
+
+Then I registered Windows Task Scheduler task `PizzaLogsLocalTestServer`. It runs at your Windows logon and every 5 minutes as a watchdog. It keeps:
+
+- Next app: `http://127.0.0.1:3001`
+- Parser: `http://127.0.0.1:8000`
+- Postgres: existing automatic Windows service on `5432`
+
+Verified by stopping the app/parser, triggering the scheduled task, and confirming both came back. HTTP checks passed for `/`, parser `/health`, and `/api/bosses`. The taskâ€™s `LastTaskResult` is `0`.
+
+Committed and pushed `7882b00` to `codex/upload-cinematic-intro`. The only remaining local change is the pre-existing unstaged `.obsidian/workspace.json`.
+
+Note: this starts after your Windows user logs in. Making it run before login would require a proper Windows service setup.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex/upload-cinematic-intro"}
+
+## User
+
+i bookmarked 3001 will it remain?
+
+## Assistant
+
+Yes. `http://127.0.0.1:3001` is the intended stable local URL now.
+
+The scheduled task is explicitly configured to keep Next running on port `3001`, and `.env.local` also points the app URL there. After a reboot, it starts when you log into Windows; give it a few seconds, or up to the 5-minute watchdog interval if something starts slowly.
+
+Your bookmark should remain valid unless we later intentionally change `.env.local`, move the repo, disable the scheduled task, or another app takes port `3001`.
+
+## User
+
+committing this?
+
+## Assistant
+
+Yes. The persistent server setup was committed and pushed:
+
+`7882b00 chore: keep local test server running`
+
+That includes the startup/stop scripts, README note, and vault handoff updates. Your actual browser bookmark is outside the repo, so thereâ€™s nothing to commit for that.
+
+## User
+
+oh i see were still working on the cinimatic branch
+
+## Assistant
+
+Correct. The persistent server setup commit is on `codex/upload-cinematic-intro`.
+
+Important detail: the scheduled task points to scripts inside this checkout. If we switch to `main` before those scripts exist on `main`, the task can break.
+
+Best next step is to move just the local server setup onto `main` with a scoped cherry-pick/merge, then keep or finish the cinematic branch separately. I can do that cleanly if you want `3001` to stay durable regardless of branch.
+
+## User
+
+yes lets stop working the branch, bring main completely up to date and delete that branch. then update .codex or what ever your memory is to always work on a branch called codex dev. i'll do PRs from now on.
+
+You are working in my Pizza Logs repository.
+
+Goal:
+Set up my Git workflow so that on my laptop, when I use Codex, I am always working from a long-lived Codex development branch, not directly from main.
+
+Branch model:
+- main = production branch
+- codex-dev = Codex working/development branch
+- codex-dev opens PRs into main
+- Railway production auto-deploys from main only
+- Codex must never push directly to main
+- Codex must never merge directly into main
+- Codex must perform proper checks before telling me a PR is ready
+
+Important:
+- Do not push to main.
+- Do not merge to main.
+- Do not overwrite existing work.
+- Do not delete branches.
+- Do not touch Railway production secrets or environment variables.
+- Do not commit .env.local, uploads, logs, node_modules, .next, parser venvs, generated junk, or local artifacts.
+- Follow all repo instructions in AGENTS.md and any project documentation.
+- Use the current repository conventions. Do not invent unnecessary tooling.
+- Keep this simple. I do not want feature branches for every task right now.
+
+Your tasks:
+
+1. Inspect the current repository state
+
+Run and review:
+
+git status
+git branch --show-current
+git remote -v
+git fetch origin
+git branch -a
+
+Check for:
+- existing main branch
+- existing codex-dev branch locally or remotely
+- uncommitted local changes
+- existing GitHub Actions workflows
+- existing package.json scripts
+- existing README/local development docs
+- existing PR template
+- existing .gitignore
+
+Do not proceed with destructive actions if there are uncommitted changes. Report them first.
+
+2. Create or normalize the Codex development branch
+
+Set up the local Codex working branch named:
+
+codex-dev
+
+The intended setup is:
+
+git checkout main
+git pull origin main
+git checkout -B codex-dev
+git push -u origin codex-dev
+
+But only do this safely.
+
+If codex-dev already exists:
+- switch to codex-dev
+- fetch origin
+- merge or rebase latest origin/main into codex-dev using the safest project convention
+- do not wipe uncommitted work
+- do not force push unless explicitly necessary and clearly explained
+
+The end state should be:
+- local branch: codex-dev
+- upstream: origin/codex-dev
+- codex-dev is up to date with main before new Codex work starts
+
+3. Add documentation for the Codex branch workflow
+
+Create or update documentation, preferably:
+
+docs/git-workflow.md
+
+If docs folder does not exist, create it.
+
+Document this workflow:
+
+Before starting Codex work:
+
+git checkout codex-dev
+git fetch origin
+git merge origin/main
+
+After Codex makes changes:
+
+git status
+npm install
+npm run lint --if-present
+npm run typecheck --if-present
+npm test --if-present
+npm run build
+
+Then:
+
+git add .
+git commit -m "..."
+git push origin codex-dev
+
+Then open PR:
+
+codex-dev â†’ main
+
+Rules:
+- main is production
+- Railway deploys production from main only
+- codex-dev is the only branch Codex should use
+- no direct commits to main
+- no direct pushes to main
+- no production deploy until PR is merged
+- if another branch or Claude branch changed the same files, stop and report conflict risk
+- after a PR merges, codex-dev must be updated from main before any new work
+
+4. Add or update PR checklist
+
+Create or update:
+
+.github/pull_request_template.md
+
+Include this checklist:
+
+## PR Safety Checklist
+
+- [ ] Source branch is `codex-dev`
+- [ ] Target branch is `main`
+- [ ] I did not push directly to `main`
+- [ ] Branch is updated from latest `main`
+- [ ] No `.env.local` or secrets committed
+- [ ] No production database URL used locally
+- [ ] No generated junk committed
+- [ ] No Railway production environment variables changed
+- [ ] `npm run lint --if-present` passes
+- [ ] `npm run typecheck --if-present` passes
+- [ ] `npm test --if-present` passes
+- [ ] `npm run build` passes
+- [ ] Upload flow tested if upload/parser code changed
+- [ ] Global search tested if player/search/roster code changed
+- [ ] Local DB reset/seed tested if Prisma/schema/seed code changed
+- [ ] Railway staging/preview tested if available
+- [ ] Rollback plan is clear
+
+5. Add GitHub Actions CI if missing or incomplete
+
+Create or update:
+
+.github/workflows/ci.yml
+
+The workflow should run on:
+- pull_request targeting main
+- push to main
+
+It should:
+- use Node 20 unless the repo clearly requires another version
+- install dependencies
+- run lint if available
+- run typecheck if available
+- run tests if available
+- run build
+- avoid failing because optional scripts are missing
+- fail if build fails
+
+Use this general shape:
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache
+
+[Truncated for vault import.]
+
+## Assistant
+
+Set up and pushed the new workflow on `codex-dev`.
+
+Current state:
+- Current branch: `codex-dev`
+- Upstream: `origin/codex-dev`
+- Latest commit pushed: `b27d29b chore: establish codex dev branch workflow`
+- Local `main` is up to date with `origin/main` at `ee09913`
+- `main` was not pushed or merged
+- `codex/upload-cinematic-intro` was not deleted because your detailed instructions said not to delete branches
+
+Changed files:
+- `.github/workflows/ci.yml`
+- `.github/pull_request_template.md`
+- `docs/git-workflow.md`
+- `docs/pr-readiness.md`
+- `AGENTS.md`
+- `README.md`
+- `.gitignore`
+- `package.json`
+- vault handoff/status files
+
+Added:
+- CI for PRs into `main` and pushes to `main`
+- PR safety checklist
+- `npm run check:pr`
+- docs saying Codex works only from `codex-dev`
+- AGENTS rule: Codex must not push or merge `main`
+
+Use before each Codex session:
+
+```bash
+git checkout codex-dev
+git fetch origin
+git merge origin/main
+git status
+```
+
+Use before asking for a PR:
+
+```bash
+npm run check:pr
+git status
+git push origin codex-dev
+```
+
+Then open PR:
+
+```text
+codex-dev -> main
+```
+
+Validation:
+- Equivalent local lint passed
+- Equivalent local type-check passed
+- `next build` passed
+- `git diff --check` passed
+- `npm run check:pr` could not be invoked literally because `npm` is not on PATH on this laptop; I ran the same underlying commands directly through the repo binaries.
+- Local test server was restored after validation; `3001` and parser health both return HTTP 200.
+
+Still manual:
+- In GitHub, protect `main`: require PR, require CI checks, block direct pushes.
+- In Railway, keep production watching `main` only. Do not point production at `codex-dev`.
+- If you want staging later, create a separate Railway environment/service with a separate DB.
+
+Remaining local change:
+- `Pizza Logs HQ/.obsidian/workspace.json` is still unstaged. I preserved it and did not commit it as workflow work.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+PR all of this and bring main up to speed
+
+## Assistant
+
+I couldnâ€™t create the PR through the GitHub connector: it returned `403 Resource not accessible by integration`, and this laptop has no `gh` CLI or GitHub token configured.
+
+I did open the prefilled PR page in your browser:
+
+[Create PR: codex-dev â†’ main](https://github.com/CRSD-Lau/Pizza-Logs/compare/main...codex-dev?quick_pull=1)
+
+Whatâ€™s ready:
+- Source: `codex-dev`
+- Target: `main`
+- Branch is pushed: `origin/codex-dev`
+- Includes all committed work: local `3001` server setup, persistent startup task scripts, Codex branch workflow, CI, PR template, docs
+- `main` was not pushed or merged by me
+
+To bring `main` up to speed: click **Create pull request**, wait for CI, then you merge it. That keeps the new rule intact.
+
+Remaining local-only change not in the PR:
+`Pizza Logs HQ/.obsidian/workspace.json`
+
+## User
+
+just gitignore it then?
+
+## Assistant
+
+Yes. I stopped tracking `Pizza Logs HQ/.obsidian/workspace.json`, added it to `.gitignore`, and confirmed the local file still exists on disk but is ignored by Git.
+
+Committed and pushed to `codex-dev`:
+
+`d2e10b9 chore: ignore local obsidian workspace state`
+
+Your PR/compare branch will include this update automatically.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+whats my db url
+
+## Assistant
+
+Your local DB URL is:
+
+`postgresql://[REDACTED]
+
+I redacted the username/password. The exact value is in:
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs\.env.local`
+
+## Assistant
+
+DBeaver is rejecting it because the URL in the popup is wrong:
+
+`postgresq://...` â† missing `l`
+
+For DBeaver, use these fields instead:
+
+- Host: `localhost`
+- Port: `5432`
+- Database: `pizzalogs`
+- Username: `pizzalogs`
+- Password: `pizzalogs`
+
+If DBeaver asks for a JDBC URL directly, use:
+
+```text
+jdbc:postgresql://[REDACTED]
+```
+
+Your appâ€™s Prisma URL is:
+
+```text
+postgresql://[REDACTED]
+```
+
+But DBeaver wants the `jdbc:postgresql://[REDACTED] form.
+
+## Assistant
+
+Now the URL is fine; DBeaver just has no password saved.
+
+Set the connection auth fields to:
+
+- Username: `pizzalogs`
+- Password: `pizzalogs`
+- Check: `Save password locally` if you want
+
+Connection details:
+
+```text
+Host: localhost
+Port: 5432
+Database: pizzalogs
+JDBC URL: jdbc:postgresql://[REDACTED]
+```
+
+Then hit **Test Connection** / reconnect.
+
+## Assistant
+
+Fill the blank auth fields:
+
+- Username: `pizzalogs`
+- Password: `pizzalogs`
+
+Everything else shown is correct:
+
+- Host: `localhost`
+- Port: `5432`
+- Database: `pizzalogs`
+- Authentication: `Username/password`
+
+Then click **Test Connection** or **OK**.
+
+## User
+
+now how can i get the import from azerothcore you did plus the tampermonkey stuff
+
+## Assistant
+
+For the **AzerothCore item import** into your local `pizzalogs` DB:
+
+```powershell
+cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+npm run db:import-items
+```
+
+On this laptop `npm` was not on PATH earlier, so if that fails, use the repo binary directly:
+
+```powershell
+cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+.\node_modules\.bin\ts-node.cmd --project tsconfig.seed.json scripts/import-item-template.ts
+```
+
+That populates `wow_items` from AzerothCore item templates. Your local DB already showed `38,610` item rows, so you may already have it.
+
+For **Tampermonkey userscripts**, open these:
+
+- Gear sync: https://pizza-logs-production.up.railway.app/api/admin/armory-gear/userscript.user.js
+- Guild roster sync: https://pizza-logs-production.up.railway.app/api/admin/guild-roster/userscript.user.js
+- Portrait sync: https://pizza-logs-production.up.railway.app/api/player-portraits/userscript.user.js
+
+Or go through:
+
+```text
+https://pizza-logs-production.up.railway.app/admin
+```
+
+Then use the install/update links under **Guild Roster** and **Warmane Gear Cache**.
+
+Important: those current userscripts post to **production Pizza Logs**, not your local `3001` test DB. If you want Tampermonkey to import into your local DB at `http://127.0.0.1:3001`, I should add local-dev userscript URLs/variants next.
+
+## User
+
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs> npm run db:import-items
+npm : File C:\Program Files\nodejs\npm.ps1 cannot be loaded because running scripts is disabled on this system. For
+more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
+At line:1 char:1
++ npm run db:import-items
++ ~~~
+    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
+    + FullyQualifiedErrorId : UnauthorizedAccess
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs>
+
+## Assistant
+
+PowerShell is blocking `npm.ps1`. Use the `.cmd` shim instead:
+
+```powershell
+npm.cmd run db:import-items
+```
+
+If that still gives trouble, run the underlying script directly:
+
+```powershell
+.\node_modules\.bin\ts-node.cmd --project tsconfig.seed.json scripts/import-item-template.ts
+```
+
+No need to change execution policy for this. PowerShell blocks `.ps1`, but `.cmd` runs normally.
+
+## User
+
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs> .\node_modules\.bin\ts-node.cmd --project tsconfig.seed.json scripts/import-item-template.ts
+Importing from: https://raw.githubusercontent.com/azerothcore/database-wotlk/refs/heads/master/sql/base/item_template.sql
+PrismaClientInitializationError:
+Invalid `prisma.$executeRaw()` invocation:
+
+
+error: Environment variable not found: DATABASE_URL.
+  -->  schema.prisma:8
+   |
+ 7 |   provider = "postgresql"
+ 8 |   url      = env("DATABASE_URL")
+   |
+
+Validation Error Count: 1
+    at $n.handleRequestError (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\@prisma\client\runtime\library.js:121:7615)
+    at $n.handleAndLogRequestError (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\@prisma\client\runtime\library.js:121:6623)
+    at $n.request (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\@prisma\client\runtime\library.js:121:6307)
+    at async l (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\@prisma\client\runtime\library.js:130:9633)
+    at async upsertBatch (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\scripts\import-item-template.ts:154:3)
+    at async main (C:\Users\neil_\OneDrive\Desktop\PizzaLogs\scripts\import-item-template.ts:262:26) {
+  clientVersion: '5.22.0',
+  errorCode: undefined
+}
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs>
+
+## Assistant
+
+That direct `ts-node` path does not auto-load `.env.local`, so Prisma cannot see `DATABASE_URL`.
+
+Run it in the same PowerShell session like this:
+
+```powershell
+$env:DATABASE_URL=[REDACTED]
+.\node_modules\.bin\ts-node.cmd --project tsconfig.seed.json scripts/import-item-template.ts
+```
+
+Or use the npm `.cmd` path, which may load it through the normal project flow:
+
+```powershell
+npm.cmd run db:import-items
+```
+
+The first option is explicit and should work.
+
+## User
+
+Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
+npm notice
+npm notice New minor version of npm available! 11.12.1 -> 11.13.0
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.13.0
+npm notice To update run: npm install -g npm@11.13.0
+npm notice
+PS C:\Users\neil_\OneDrive\Desktop\PizzaLogs> npm install -g npm@11.13.0
+npm : File C:\Program Files\nodejs\npm.ps1 cannot be loaded because running scripts is disabled on this system. For
+more information, see about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.
+At line:1 char:1
++ npm install -g npm@11.13.0
++ ~~~
+    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
+    + FullyQualifiedErrorId : UnauthorizedAccess
+
+## Assistant
+
+Donâ€™t update npm right now. That was just a notice, and PowerShell is blocking `npm.ps1`.
+
+Use `.cmd` commands instead:
+
+```powershell
+npm.cmd install -g npm@11.13.0
+```
+
+But for your actual AzerothCore import, skip npm entirely and run:
+
+```powershell
+cd C:\Users\neil_\OneDrive\Desktop\PizzaLogs
+
+$env:DATABASE_URL=[REDACTED]
+
+.\node_modules\.bin\ts-node.cmd --project tsconfig.seed.json scripts/import-item-template.ts
+```
+
+If you want to verify after:
+
+```powershell
+$env:DATABASE_URL=[REDACTED]
+
+.\node_modules\.bin\prisma.cmd studio
+```
+
+Or check in DBeaver: table `wow_items` should have tens of thousands of rows.
+
+## User
+
+yes add the local scripts as well
+
+## Assistant
+
+Added the local scripts and pushed them to `origin/codex-dev`.
+
+Local install URLs:
+- Gear: `http://127.0.0.1:3001/api/admin/armory-gear/userscript.local.user.js`
+- Roster: `http://127.0.0.1:3001/api/admin/guild-roster/userscript.local.user.js`
+- Portraits: `http://127.0.0.1:3001/api/player-portraits/userscript.local.user.js`
+
+I also added local install buttons on `/admin`, updated the vault handoff files, committed the work, and pushed `codex-dev`. Current working tree is clean.
+
+Validation passed: focused userscript/admin tests, local route tests, ESLint, TypeScript, `next build`, and live `127.0.0.1:3001` endpoint checks.
+
+I could not create the PR from here because the GitHub connector returned `403 Resource not accessible by integration`. Open it here:
+[Create PR: codex-dev -> main](https://github.com/CRSD-Lau/Pizza-Logs/compare/main...codex-dev?expand=1)
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+Runtime Error
+
+
+Cannot find module './5611.js'
+Require stack:
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\.next\server\webpack-runtime.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\.next\server\pages\_document.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\server\require.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\server\load-components.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\build\utils.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\build\swc\options.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\build\swc\index.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\build\next-config-ts\transpile-config.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\server\config.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\server\next.js
+- C:\Users\neil_\OneDrive\Desktop\PizzaLogs\node_modules\next\dist\server\lib\start-server.js
+
+## Assistant
+
+Fixed. The `3001` dev server was using a corrupted/mixed `.next` cache: the runtime expected `./5611.js`, but the generated chunk was under `.next/server/chunks/5611.js`. That likely happened because `next build` ran while the long-running dev server was active.
+
+I stopped the stale Next process, removed only the generated `.next` folder, restarted the existing `PizzaLogsLocalTestServer` scheduled task, and verified:
+
+- `http://127.0.0.1:3001/` returns `200`
+- no `Cannot find module` runtime error in the response
+- local userscript endpoint returns `200`
+- scheduled task result is now `0`
+- git working tree is clean
+
+I also recorded the recovery in the vault and pushed it to `origin/codex-dev` as `050e5ca`.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+lets do the pull request
+
+## Assistant
+
+I opened the GitHub compare page for `codex-dev -> main` with the title/body prefilled:
+
+[Create PR](https://github.com/CRSD-Lau/Pizza-Logs/compare/main...codex-dev?quick_pull=1)
+
+I canâ€™t click the final create button from here because the GitHub connector is write-blocked with `403`, and `gh` is not installed. The branch is clean and pushed: `codex-dev` at `050e5ca`.
+
+On the GitHub page, confirm:
+- base: `main`
+- compare: `codex-dev`
+- create as draft if GitHub gives that option
+- then click create pull request.
+
+## User
+
+why cant connector write and i have gh cli installed
+
+## Assistant
+
+Two separate blockers:
+
+1. GitHub connector cannot write:
+The connector returned `403 Resource not accessible by integration`. That means the Codex GitHub App/token can read this repo, but it does not currently have permission to create PRs for `CRSD-Lau/Pizza-Logs`. That has to be fixed in the GitHub App/connector installation permissions.
+
+2. `gh` is installed but not usable yet:
+`gh.exe` exists here:
+
+`C:\Program Files\GitHub CLI\gh.exe`
+
+But it is not on this Codex shellâ€™s `PATH`, so plain `gh` failed. Calling it by full path works, but it is not logged in:
+
+`You are not logged into any GitHub hosts.`
+
+Run this once in PowerShell:
+
+```powershell
+& 'C:\Program Files\GitHub CLI\gh.exe' auth login
+```
+
+After that, tell me, and I can create the PR with the full `gh.exe` path.
+
+## User
+
+Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows
+
+PS C:\WINDOWS\system32> & 'C:\Program Files\GitHub CLI\gh.exe' auth login
+>> & 'C:\Program Files\GitHub CLI\gh.exe' auth login
+>>
+? Where do you use GitHub? GitHub.com
+? What is your preferred protocol for Git operations on this host? HTTPS
+? Authenticate Git with your GitHub credentials? Yes
+? How would you like to authenticate GitHub CLI? Paste an authentication token
+Tip: you can generate a Personal Access Token here https://github.com/settings/tokens
+The minimum required scopes are 'repo', 'read:org', 'workflow'.
+? Paste your authentication token:
+X Sorry, your reply was invalid: Value is required
+X Sorry, your reply was invalid: Value is required
+? Paste your authentication token: *************************************************************************************- gh config set -h github.com git_protocol https
+âœ“ Configured git protocol
+unable to find git executable in PATH; please install Git for Windows before retrying
+? Where do you use GitHub?  [Use arrows to move, type to filter]
+> GitHub.com
+  Other
+
+## User
+
+yeah i did it manually
+
+## Assistant
+
+Yep, I see it. PR #7 is merged into `main`, and I fast-forwarded/pushed `codex-dev` to the same commit as `origin/main`.
+
+Current state:
+- branch: `codex-dev`
+- clean working tree
+- `codex-dev`, `origin/codex-dev`, and `origin/main` all at `cd6d21a`
+- PR: [#7 Refresh workflow docs and add local userscript routes](https://github.com/CRSD-Lau/Pizza-Logs/pull/7)
+
+`codex-dev` is ready for the next Codex task.
+
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+and now going forward you can do all of my checks and PRs and Merges?
+
+## Assistant
+
+Yes for checks and PRs.
+
+Going forward I can:
+- run local validation: lint, type-check, tests, build
+- review staged/untracked files before committing
+- commit to `codex-dev`
+- push `origin/codex-dev`
+- create PRs with `gh.exe`
+- check PR status/checks
+- update `codex-dev` from `main` after a merge
+
+Merges: under the repo rules we just set, I should not merge into `main` for you. Merging `codex-dev -> main` triggers Railway production, so the safer model is: I prepare and verify the PR, you click merge after reviewing GitHub checks.
+
+The GitHub CLI is usable now, but Iâ€™ll call it by full path and add Git to PATH inside the session:
+
+```powershell
+$env:Path = 'C:\Program Files\Git\cmd;C:\Program Files\GitHub CLI;' + $env:Path
+```
+
+So the normal workflow is: I do checks, commit, push, open PR; you merge; I sync `codex-dev` back up to `main`.
+
+## User
+
+perfect
+
+## Assistant
+
+Good. Thatâ€™s the workflow Iâ€™ll follow from here:
+
+`codex-dev` for all work, PR into `main`, you merge, then I sync `codex-dev` back to `main`.
+
+## User
+
+do these tampermonkey scripts break my live ones? do i need to swap between the two
+
+## Assistant
+
+They do **not break** the live ones. They are separate Tampermonkey installs because the local versions have ` (Local)` in the name and use `http://127.0.0.1:3001` as their namespace/update URL.
+
+But yes, you should **toggle between live and local for gear/roster**.
+
+Recommended:
+
+- Working on local DB: enable
+  - `Pizza Logs Warmane Gear Auto Sync (Local)`
+  - `Pizza Logs Warmane Guild Roster Sync (Local)`
+- Working on production: enable
+  - `Pizza Logs Warmane Gear Auto Sync`
+  - `Pizza Logs Warmane Guild Roster Sync`
+
+Do not leave both gear/roster versions enabled at the same time, because both match Warmane pages. You could get duplicate buttons, duplicate sync attempts, or the same saved Warmane-page admin secret being used against the wrong target.
+
+Portraits are lower risk because they do not import to the DB, but Iâ€™d still keep only one portrait script enabled to avoid double work on the page.
+
+## User
+
+Portrits never worked. always just falls back to class icon
+
+## Assistant
+
+You were right: portraits were effectively stuck on class icons.
+
+Root cause: the Wowhead/Zamimg modelviewer iframe could load before the Warmane parent page wrote the character identity into Tampermonkey storage. The old script saw â€œno character target,â€ skipped capture, and never retried. I fixed that race and bumped the portrait userscript to `0.5.1`.
+
+PR is open as draft: [#8 Fix portrait userscript modelviewer handoff](https://github.com/CRSD-Lau/Pizza-Logs/pull/8)
+
+Validated:
+- portrait userscript regression test passes
+- local userscript route test passes
+- ESLint passes
+- TypeScript passes
+- `next build` passes
+- local `3001` portrait script returns `0.5.1`
+
+After this PR merges, update/reinstall the portrait userscript from `/admin`, then visit a Warmane character page and refresh the Pizza Logs player page. Direct automation still hits Warmaneâ€™s Cloudflare verification on pages like [Warmane Armory](https://armory.warmane.com/character/Lausudo/Lordaeron/summary), so this remains browser-assisted.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+::git-create-pr{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev" url="https://github.com/CRSD-Lau/Pizza-Logs/pull/8" isDraft=true}
+
+## User
+
+## Error Type
+Console Error
+
+## Error Message
+A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+
+- A server/client branch `if (typeof window !== 'undefined')`.
+- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
+- Date formatting in a user's locale which doesn't match the server.
+- External changing data without sending a snapshot of it along with the HTML.
+- Invalid HTML tag nesting.
+
+It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
+
+https://react.dev/link/hydration-mismatch
+
+  ...
+    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+      <RedirectBoundary>
+        <RedirectErrorBoundary router={{...}}>
+          <InnerLayoutRouter url="/guild-roster" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+            <SegmentViewNode type="page" pagePath="guild-rost...">
+              <SegmentTrieNode>
+              <GuildRosterPage>
+                <div className="pt-10 spac...">
+                  <div>
+                  <GuildRosterTable>
+                    <div className="overflow-x...">
+                      <table className="min-w-full...">
+                        <thead>
+                        <tbody>
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Maximusboom" realmName="Lordaeron" characterClass="Druid" ...>
+                                  <div
+                                    aria-label="Maximusboom avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justify-center overflow-hidd..."
+                                    data-pizza-avatar="character"
+                                    data-pizza-avatar-state="fallback-icon"
+                                    data-character-name="Maximusboom"
+                                    data-character-realm="Lordaeron"
+                                    data-character-class="Druid"
+                                    data-character-race="Night Elf"
+                                    data-character-guild="PizzaWarriors"
+                                    data-initials="MA"
+                                    data-portrait-url=""
+                                    data-fallback-icon-url="https://wow.zamimg.com/images/wow/icons/large/classicon_dr..."
+                                    style={{background:"#f0a04022",color:"#f0a040",border:"1px solid ..."}}
+-                                   data-pizza-portrait-queued="1"
+                                  >
+                                ...
+                            ...
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Lichkingspet" realmName="Lordaeron" characterClass="Death Knight" ...>
+                                  <div
+                                    aria-label="Lichkingspet avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justify-center overflow-hidd..."
+                                    data-pizza-avatar="character"
+                                    data-pizza-avatar-state="fallback-icon"
+                                    data-character-name="Lichkingspet"
+                                    data-character-realm="Lordaeron"
+                                    data-character-class="Death Knight"
+                                    data-character-race="Human"
+                                    data-character-guild="PizzaWarriors"
+                                    data-initials="LI"
+                                    data-portrait-url=""
+                                    data-fallback-icon-url="https://wow.zamimg.com/images/wow/icons/large/classicon_de..."
+                                    style={{background:"#c41e3a22",color:"#c41e3a",border:"1px solid ..."}}
+-                                   data-pizza-portrait-queued="1"
+                                  >
+                                ...
+                            ...
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Azyia" realmName="Lordaeron" characterClass="Paladin" ...>
+                                  <div
+                                    aria-label="Azyia avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justi
+
+[Truncated for vault import.]
+
+## Assistant
+
+Fixed and pushed to draft PR #8: [https://github.com/CRSD-Lau/Pizza-Logs/pull/8](https://github.com/CRSD-Lau/Pizza-Logs/pull/8)
+
+Root cause was the Tampermonkey portrait script mutating SSR avatar DOM before React hydration by adding `data-pizza-portrait-queued="1"`. I changed [lib/player-portrait-client-scripts.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/lib/player-portrait-client-scripts.ts:65) to track queued avatars in an in-memory `WeakSet` instead, bumped the userscript to `0.5.2`, and added a regression assertion in [tests/player-portrait-client-scripts.test.ts](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/tests/player-portrait-client-scripts.test.ts:159).
+
+Verified:
+- Regression test failed first with `'1' !== undefined`, then passed after the fix
+- `player-portrait-client-scripts`, `local-userscript-routes`, and `warmane-portrait` tests passed
+- ESLint, TypeScript, and `next build` passed
+- Local `3001` restarted cleanly; `/` is 200 and portrait userscript endpoint is 200 with `0.5.2` and no queued marker
+- GitHub CI `test-build` passed on PR #8
+
+Commit pushed: `b550730 Fix portrait userscript hydration marker`.
+
+::git-stage{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-commit{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs"}
+::git-push{cwd="C:/Users/neil_/OneDrive/Desktop/PizzaLogs" branch="codex-dev"}
+
+## User
+
+i cant remember i dont need to pr to test local right?
+
+## Assistant
+
+Right, you do **not** need the PR merged to test local.
+
+Use local for testing:
+
+- App: `http://127.0.0.1:3001`
+- Local portrait userscript: `http://127.0.0.1:3001/api/player-portraits/userscript.local.user.js`
+
+For this fix, update/reinstall the **Local** portrait userscript so Tampermonkey gets version `0.5.2`, then test:
+
+`http://127.0.0.1:3001/guild-roster`
+
+You only need the PR merged when you want the fix on the live Railway site at `pizza-logs-production.up.railway.app`.
+
+## User
+
+## Error Type
+Console Error
+
+## Error Message
+A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:
+
+- A server/client branch `if (typeof window !== 'undefined')`.
+- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
+- Date formatting in a user's locale which doesn't match the server.
+- External changing data without sending a snapshot of it along with the HTML.
+- Invalid HTML tag nesting.
+
+It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
+
+https://react.dev/link/hydration-mismatch
+
+  ...
+    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+      <RedirectBoundary>
+        <RedirectErrorBoundary router={{...}}>
+          <InnerLayoutRouter url="/guild-roster" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+            <SegmentViewNode type="page" pagePath="guild-rost...">
+              <SegmentTrieNode>
+              <GuildRosterPage>
+                <div className="pt-10 spac...">
+                  <div>
+                  <GuildRosterTable>
+                    <div className="overflow-x...">
+                      <table className="min-w-full...">
+                        <thead>
+                        <tbody>
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Maximusboom" realmName="Lordaeron" characterClass="Druid" ...>
+                                  <div
+                                    aria-label="Maximusboom avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justify-center overflow-hidd..."
+                                    data-pizza-avatar="character"
+                                    data-pizza-avatar-state="fallback-icon"
+                                    data-character-name="Maximusboom"
+                                    data-character-realm="Lordaeron"
+                                    data-character-class="Druid"
+                                    data-character-race="Night Elf"
+                                    data-character-guild="PizzaWarriors"
+                                    data-initials="MA"
+                                    data-portrait-url=""
+                                    data-fallback-icon-url="https://wow.zamimg.com/images/wow/icons/large/classicon_dr..."
+                                    style={{background:"#f0a04022",color:"#f0a040",border:"1px solid ..."}}
+-                                   data-pizza-portrait-queued="1"
+                                  >
+                                ...
+                            ...
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Lichkingspet" realmName="Lordaeron" characterClass="Death Knight" ...>
+                                  <div
+                                    aria-label="Lichkingspet avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justify-center overflow-hidd..."
+                                    data-pizza-avatar="character"
+                                    data-pizza-avatar-state="fallback-icon"
+                                    data-character-name="Lichkingspet"
+                                    data-character-realm="Lordaeron"
+                                    data-character-class="Death Knight"
+                                    data-character-race="Human"
+                                    data-character-guild="PizzaWarriors"
+                                    data-initials="LI"
+                                    data-portrait-url=""
+                                    data-fallback-icon-url="https://wow.zamimg.com/images/wow/icons/large/classicon_de..."
+                                    style={{background:"#c41e3a22",color:"#c41e3a",border:"1px solid ..."}}
+-                                   data-pizza-portrait-queued="1"
+                                  >
+                                ...
+                            ...
+                          <tr className="reveal-ite..." style={{...}}>
+                            <td className="px-4 py-3">
+                              <div className="flex items...">
+                                <PlayerAvatar name="Azyia" realmName="Lordaeron" characterClass="Paladin" ...>
+                                  <div
+                                    aria-label="Azyia avatar"
+                                    className="rounded-sm flex-shrink-0 flex items-center justi
+
+[Truncated for vault import.]
+
+## User
+
+i forgot to update the userscript no more error but still class icons. its ok. lets just stik with class icons, I kinda like them
+
+## Assistant
+
+Yep, class icons are the cleaner path.
+
+For local testing, just keep the **gear** and **roster** userscripts installed. Disable or uninstall only:
+
+`Pizza Logs Warmane Portraits (Local)`
+
+The app already falls back to class icons, and your hydration error was just the old portrait userscript version still installed. I removed the extra uncommitted guard work I had started; worktree is clean on `codex-dev`.
+
+## User
+
+do we need the Front end script code now? what about any back end code that might be stale or no loner used? any documentation that needs updating since were just gonna stick with class icons
+
+## Assistant
+
+Done. We do not need the active front-end portrait script now.
+
+I retired the portrait capture path and kept class icons as the intentional avatar behavior. The old `/api/player-portraits/...` userscript URLs still exist, but they now serve a no-op compatibility script so old Tampermonkey installs can update to harmless code or be uninstalled.
+
+Cleaned up stale code:
+- Removed portrait install UI from `/admin`.
+- Removed `portraitUrl` plumbing from player/profile/roster/session views.
+- Deleted old portrait extraction helper and replaced it with `lib/class-icons.ts`.
+- Simplified `PlayerAvatar` to class icon + initials fallback only.
+- Updated README, security/review docs, and vault handoff/current-focus/known-issues notes.
+
+Pushed to draft PR #8: https://github.com/CRSD-Lau/Pizza-Logs/pull/8
+Commit: `12b50c2 Retire portrait userscript in favor of class icons`
+
+Verification passed locally and in GitHub CI:
+- Focused TS/TSX tests
+- ESLint
+- `tsc --noEmit`
+- `next build`
+- Local `3001` app and local gear/roster/no-op portrait endpoints
+
+`http://127.0.0.1:3001` is running again.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev"}
+
+## User
+
+not sure if i merged this or not
+
+## Assistant
+
+No, this one is not merged.
+
+I checked GitHub and git refs:
+
+- PR #8 is still **OPEN** and **draft**: https://github.com/CRSD-Lau/Pizza-Logs/pull/8
+- `origin/main` does **not** contain commit `12b50c2`
+- The class-icon cleanup is on `codex-dev`
+- CI passed on PR #8
+
+So production/main does not have the â€œstick with class icons / retire portrait userscriptâ€ cleanup yet. Youâ€™d need to mark PR #8 ready and merge it into `main` for Railway production to pick it up.
+
+## User
+
+can you provide me a start and stop script for all three services i can keep on my desktop? the random powershell every 5 minutes is annoying
+
+## Assistant
+
+Done.
+
+You now have these two Desktop launchers:
+
+- `C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd`
+- `C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd`
+
+I also disabled the repeating `PizzaLogsLocalTestServer` scheduled task, so the every-5-min PowerShell popup should stop.
+
+Behavior:
+- Start script starts PostgreSQL if needed, parser on `8000`, and Next on `3001`.
+- Stop script stops the web/parser processes. PostgreSQL requires admin rights on this machine, so right-click `Stop Pizza Logs Local.cmd` and choose **Run as administrator** when you want it to stop all three.
+
+Validated:
+- Stop script stopped web/parser.
+- Start script brought web/parser back.
+- `http://127.0.0.1:3001/` returned 200.
+- `http://127.0.0.1:8000/health` returned 200.
+- Scheduled task is disabled.
+
+This is pushed as draft PR #9, CI passed: https://github.com/CRSD-Lau/Pizza-Logs/pull/9
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev"}
+::git-create-pr{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev" url="https://github.com/CRSD-Lau/Pizza-Logs/pull/9" isDraft=true}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - audit-and-clean-docs.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - audit-and-clean-docs.md
@@ -1,0 +1,210 @@
+# Audit and clean docs
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-05
+- Thread id: `019df619-6170-7ac2-9de8-7cb32d30d441`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\05\rollout-2026-05-05T00-05-51-019df619-6170-7ac2-9de8-7cb32d30d441.jsonl`
+- Imported user turns: 1
+- Imported assistant final replies: 1
+- Tool/command events omitted: 136
+
+## Discussion Digest
+
+## User
+
+You are working in the Pizza Logs repository.
+
+Goal:
+Perform a full documentation and repository freshness audit. Remove, rewrite, or update anything stale, misleading, duplicated, obsolete, or no longer useful.
+
+Scope:
+- Review the entire codebase before editing documentation.
+- Review every `.md` file in the repo, including:
+  - README files
+  - docs folders
+  - wiki/exported docs
+  - Obsidian vault notes
+  - setup guides
+  - deployment notes
+  - architecture notes
+  - parser notes
+  - testing notes
+  - roadmap/backlog docs
+  - package/release docs
+  - contribution/community files
+- Review GitHub-facing repo files:
+  - root README.md
+  - CONTRIBUTING.md
+  - CODE_OF_CONDUCT.md
+  - SECURITY.md if present
+  - issue templates
+  - PR templates
+  - release/package docs
+  - any docs linked from README
+
+Primary instructions:
+1. First, map the current repo structure.
+2. Identify the actual current state of the application by inspecting:
+   - package.json scripts and dependencies
+   - app routes/pages
+   - API routes
+   - database/schema/migrations
+   - parser logic
+   - upload flow
+   - admin page
+   - player/gear features
+   - guild roster features
+   - leaderboards/raid sessions
+   - Railway/deployment configuration
+   - test setup
+   - environment variables
+3. Use the codebase as the source of truth.
+4. Compare all documentation against the current implementation.
+5. Delete documentation that no longer serves a purpose.
+6. Update documentation that is useful but stale.
+7. Consolidate duplicate docs where practical.
+8. Remove old Claude-specific references unless they are still genuinely useful.
+9. Replace outdated AI workflow references with current Codex-first workflow language.
+10. Ensure README and setup docs reflect the current production deployment and local development process.
+
+Important:
+- Do not preserve stale docs just because they exist.
+- Do not create bloated documentation.
+- Prefer fewer, cleaner, accurate docs over many partial docs.
+- Do not invent features that are not implemented.
+- Do not document aspirational functionality as if it exists.
+- Clearly separate current functionality from roadmap/backlog items.
+- Remove dead links, dead setup steps, obsolete commands, and outdated screenshots references.
+- Update docs that mention broken or removed flows such as unused fallback buttons, old upload analytics placement, deprecated gear enrichment methods, or abandoned scraper assumptions.
+- Ensure any Warmane, Tampermonkey, AzerothCore DB, parser, and Railway notes reflect the current design.
+
+Required review areas:
+- Root README accuracy
+- Local setup instructions
+- Environment variable documentation
+- Database setup and migration instructions
+- Railway deployment notes
+- Parser behavior and known limitations
+- Upload behavior
+- Admin page functionality
+- Player gear cache / Warmane / Tampermonkey flow
+- Guild roster flow
+- Raid sessions and leaderboards behavior
+- Security notes for uploads and file handling
+- Testing instructions
+- NPM/package release notes if applicable
+- GitHub community files
+- Obsidian/internal notes that are now stale, duplicated, or misleading
+
+Execution plan:
+1. Create or switch to the Codex development branch:
+   - `git fetch --all --prune`
+   - `git checkout codex-dev` if it exists
+   - otherwise create it from latest main
+   - sync with main before starting
+2. Inventory documentation:
+   - list every `.md` file
+   - identify docs that are current, stale, duplicate, obsolete, or unclear
+3. Inventory implementation:
+   - inspect relevant source files and configs to understand actual behavior
+4. Produce a short audit summary before editing:
+   - docs to delete
+   - docs to update
+   - docs to consolidate
+   - repo-facing docs needing README updates
+5. Apply changes.
+6. Run formatting/lint/tests/build commands available in package.json.
+7. Fix any issues caused by doc or config changes.
+8. Review git diff carefully.
+9. Commit all safe documentation and repo metadata changes.
+10. Push the branch to remote.
+11. Prepare a PR from `codex-dev` into `main`.
+
+Guardrails:
+- Do not edit secrets.
+- Do not commit `.env`, local database files, logs, build artifacts, cache folders, or generated junk.
+- If files appear sensitive or machine-specific, add them to `.gitignore` instead of committing them.
+- If unsure whether a doc is obsolete, verify against code before deleting it.
+- If a doc contains useful historical context but should not be primary documentation, move/consolidate the still-useful parts into the right current doc and delete the stale original.
+- Keep the tone professional, concise, and repo-maintainer friendly.
+- Avoid marketing language.
+- Avoid over-documenting obvious code behavior.
+
+README expectations:
+The final root README should clearly explain:
+- what Pizza Logs is
+- current major features
+- supported WoW/Warmane assumptions
+- local development setup
+- database setup
+- environment variables
+- upload/parsing flow
+- admin tools
+- player/gear/guild roster enrichme
+
+[Truncated for vault import.]
+
+## Assistant
+
+Completed and pushed on `codex-dev`.
+
+**Deleted**
+- Obsolete Superpowers cinematic intro plan/spec docs.
+- Empty/stale vault inbox note.
+- Duplicate AI control docs and old Claude/prompt/skills reference notes.
+- Stale standalone backlog, technical debt, and growth/business notes after consolidating useful content.
+
+**Updated / Consolidated**
+- Rewrote `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`, Git workflow/review docs, deployment/security/parser docs, and the active Obsidian vault handoff/current-state notes.
+- Consolidated backlog and technical debt into `Pizza Logs HQ/05 Features/Feature Status.md`.
+- Replaced old Claude-first workflow language with Codex-first `codex-dev -> PR -> main` workflow.
+- Trimmed `.env.example` to currently active env vars only.
+
+**README / Community Files**
+- README now covers current features, Warmane assumptions, parser/upload flow, admin tools, roster/gear enrichment, local setup, Railway deployment, tests, limitations, and contribution workflow.
+- GitHub PR template now calls out parser validation when parser behavior changes.
+- CI now runs parser pytest in addition to web validation.
+
+**Not Changed**
+- Found that `/api/upload` still lacks hard server-side file-size enforcement. I documented this as a known limitation instead of changing code in a docs-only audit.
+
+**Validation**
+- ESLint: passed.
+- TypeScript `tsc --noEmit`: passed.
+- Parser tests: `123 passed`.
+- Next production build: passed.
+- Obsidian wiki-link scan: passed.
+- Stale-reference scan: passed.
+- `git diff --check`: passed.
+- Secret scan of staged diff: placeholders/docs only.
+
+Commit: `ad4af43 docs: refresh repository documentation`
+
+Push: `origin/codex-dev` is up to date and the working tree is clean.
+
+PR creation could not be completed automatically: GitHub connector returned `403 Resource not accessible by integration`, and `gh` is not installed locally. Exact PR command once GitHub CLI is available/authenticated:
+
+```powershell
+gh pr create --draft --repo CRSD-Lau/Pizza-Logs --base main --head codex-dev --title "[codex] refresh repository documentation" --body "## Summary
+- Refresh README, contributor/security/workflow docs, and the Obsidian vault around the current Codex-first branch flow.
+- Remove obsolete duplicate docs and consolidate feature backlog/technical-debt notes into Feature Status.
+- Document current Warmane roster/gear/portrait flows, parser edge cases, Railway deployment, and known upload/security limitations.
+- Add parser pytest validation to GitHub Actions.
+
+## Validation
+- ESLint via bundled Node: passed.
+- TypeScript tsc --noEmit via bundled Node: passed.
+- Next production build via bundled Node: passed.
+- Parser tests via bundled Python: 123 passed.
+- Stale-reference and Obsidian wiki-link scans: passed.
+- git diff --cached --check: passed.
+- Staged secret scan: placeholders/docs only."
+```
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev"}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - move-project-to-local-github.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - move-project-to-local-github.md
@@ -1,0 +1,170 @@
+# Move project to local GitHub
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-05
+- Thread id: `019df866-fa7a-7951-9142-c831bdf80780`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\05\rollout-2026-05-05T10-49-51-019df866-fa7a-7951-9142-c831bdf80780.jsonl`
+- Imported user turns: 6
+- Imported assistant final replies: 6
+- Tool/command events omitted: 165
+
+## Discussion Digest
+
+## User
+
+What would be the fastest way to copy my project from my onedrive desktop to c:\Projects locally and just work out of Github
+
+## Assistant
+
+Fastest clean path: **do not copy the whole OneDrive folder**. Clone fresh from GitHub into `C:\Projects`. Your current checkout is clean on `codex-dev`, `origin` is `https://github.com/CRSD-Lau/Pizza-Logs.git`, `C:\Projects` exists, and `C:\Projects\PizzaLogs` is free.
+
+```powershell
+cd C:\Projects
+& 'C:\Program Files\Git\cmd\git.exe' clone https://github.com/CRSD-Lau/Pizza-Logs.git PizzaLogs
+cd C:\Projects\PizzaLogs
+& 'C:\Program Files\Git\cmd\git.exe' checkout codex-dev
+& 'C:\Program Files\Git\cmd\git.exe' fetch origin
+& 'C:\Program Files\Git\cmd\git.exe' merge origin/main
+npm ci --legacy-peer-deps
+npm run db:generate
+```
+
+Then copy only local config/secrets you need, not `node_modules`, `.next`, caches, logs, or combat logs:
+
+```powershell
+Copy-Item 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs\.env.local' 'C:\Projects\PizzaLogs\.env.local' -ErrorAction SilentlyContinue
+Copy-Item 'C:\Users\neil_\OneDrive\Desktop\PizzaLogs\.env.sync-agent' 'C:\Projects\PizzaLogs\.env.sync-agent' -ErrorAction SilentlyContinue
+```
+
+For this repo, that is better than copying because OneDrive has already caused local tooling/ACL weirdness. After the move, point Codex and your launchers at `C:\Projects\PizzaLogs`, and keep the GitHub workflow as `codex-dev -> PR -> main`.
+
+## User
+
+does this break anything to do with my local?
+
+## Assistant
+
+No, it should not break production or your GitHub workflow. Moving to `C:\Projects\PizzaLogs` mostly changes the **local working folder path**.
+
+Things that keep working after a fresh GitHub clone:
+
+- GitHub remote, branches, PR flow
+- App source code and committed Obsidian vault files
+- Production Railway deploys from `main`
+- Local database data, as long as `.env.local` still points to the same `DATABASE_URL`
+- Local userscripts that post to `http://127.0.0.1:3001`, because the URL does not care where the repo lives
+
+Things you need to update or recreate:
+
+- Copy `.env.local` and `.env.sync-agent` from the OneDrive repo
+- Reinstall `node_modules` with `npm ci --legacy-peer-deps`
+- Run `npm run db:generate`
+- Recreate the parser venv if you use it locally
+- Update desktop launchers/shortcuts that currently point to `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Start only one local app at a time, or ports like `3001` may conflict
+
+Best safety move: leave the OneDrive copy alone for a few days. Clone to `C:\Projects`, copy env files, run the app locally, verify upload/admin/parser basics, then retire the OneDrive folder once the new path is proven.
+
+## User
+
+test environment
+
+## Assistant
+
+I set up and tested `C:\Projects\PizzaLogs` as the local test environment.
+
+Passed from `C:\Projects\PizzaLogs`:
+
+- `npm ci --legacy-peer-deps`
+- `npm run db:generate`
+- `npm run type-check`
+- `npm run lint`
+- `npm run build`
+- Parser tests: `133 passed, 1 warning`
+- Web server: `http://127.0.0.1:3001/` returns `200`
+- Parser health: `http://127.0.0.1:8000/health` returns `200`
+
+One local blocker: PostgreSQL service `postgresql-x64-16` is stopped, and this session could not start it without elevated Windows permissions. DB-backed API routes currently return `500` until PostgreSQL is started.
+
+Also, your desktop launchers still point at:
+
+`C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+
+Next practical step is retargeting those Start/Stop launchers to `C:\Projects\PizzaLogs`, then starting PostgreSQL once as admin. I left the web/parser test services running on ports `3001` and `8000`.
+
+## User
+
+do it
+
+## Assistant
+
+Done.
+
+`C:\Projects\PizzaLogs` is now the local working checkout. The desktop Start/Stop launchers on your Desktop now point there, and the repo launcher templates were updated too.
+
+Verified:
+
+- Web: `http://127.0.0.1:3001/` returns `200`
+- Parser: `http://127.0.0.1:8000/health` returns `200`
+- `C:\Projects\PizzaLogs` worktree is clean
+- OneDrive repo worktree is clean
+- Pushed `origin/codex-dev`
+- Opened draft PR: [#11 Retarget local launchers to Projects checkout](https://github.com/CRSD-Lau/Pizza-Logs/pull/11)
+
+Only remaining local issue: PostgreSQL service `postgresql-x64-16` is still stopped. Windows blocked starting it from this non-admin session, so DB-backed pages may return `500` until you start PostgreSQL once as admin.
+
+::git-stage{cwd="C:\Projects\PizzaLogs"}
+::git-commit{cwd="C:\Projects\PizzaLogs"}
+::git-push{cwd="C:\Projects\PizzaLogs" branch="codex-dev"}
+::git-create-pr{cwd="C:\Projects\PizzaLogs" branch="codex-dev" url="https://github.com/CRSD-Lau/Pizza-Logs/pull/11" isDraft=true}
+
+## User
+
+can we move the start and stops to the pizzalogs folder
+
+## Assistant
+
+Done. The launchers now live in the PizzaLogs folder:
+
+- [Start Pizza Logs Local.cmd](</C:/Projects/PizzaLogs/Start Pizza Logs Local.cmd>)
+- [Stop Pizza Logs Local.cmd](</C:/Projects/PizzaLogs/Stop Pizza Logs Local.cmd>)
+
+I removed the old Desktop copies and deleted the duplicate `scripts/desktop` templates. The root launchers now resolve the repo path from their own location, so they are less brittle.
+
+Verified both launchers: Stop then Start worked, web is `200` at `http://127.0.0.1:3001/`, parser health is `200` at `http://127.0.0.1:8000/health`. Pushed commit `8244651` to `origin/codex-dev`; draft PR #11 is updated.
+
+::git-stage{cwd="C:\Projects\PizzaLogs"}
+::git-commit{cwd="C:\Projects\PizzaLogs"}
+::git-push{cwd="C:\Projects\PizzaLogs" branch="codex-dev"}
+
+## User
+
+how do i point my codex project to this new local folder
+
+## Assistant
+
+Click the small **pencil/edit icon** beside the `PizzaLogs` project name in the sidebar.
+
+Set the project/workspace folder to:
+
+```text
+C:\Projects\PizzaLogs
+```
+
+Then save and start a new chat under that project. In the new chat, sanity-check it with:
+
+```powershell
+Get-Location
+```
+
+It should return:
+
+```text
+C:\Projects\PizzaLogs
+```
+
+If Codex does not let you edit the existing project path, create a new project/open folder and select `C:\Projects\PizzaLogs`, then use that one going forward. The old OneDrive project can stay around until youâ€™re sure everything is smooth.

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - refactor-parser-and-upload-flow.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/2026-05-05 - refactor-parser-and-upload-flow.md
@@ -1,0 +1,179 @@
+# Refactor parser and upload flow
+
+> Imported from local Codex session logs on 2026-05-05. This is a readable chat digest, not the raw JSONL transcript.
+
+## Metadata
+
+- Session date: 2026-05-05
+- Thread id: `019df83e-24d7-70d1-b291-9d87dec60e83`
+- Original cwd: `C:\Users\neil_\OneDrive\Desktop\PizzaLogs`
+- Source log: `C:\Users\neil_\.codex\sessions\2026\05\05\rollout-2026-05-05T10-05-15-019df83e-24d7-70d1-b291-9d87dec60e83.jsonl`
+- Imported user turns: 1
+- Imported assistant final replies: 1
+- Tool/command events omitted: 179
+
+## Discussion Digest
+
+## User
+
+You are working in my Pizza Logs repository.
+
+Goal:
+Perform a full deep-dive, test-driven refactor of parser.py and the complete wowcombatlog.txt upload parsing flow.
+
+Reference repositories:
+- https://github.com/Ridepad/uwu-logs
+- https://github.com/bkader/Skada-WoTLK
+
+Context:
+Pizza Logs is a WotLK 3.3.5a / Warmane-focused combat log parser. The parser must be accurate for uploaded end-user WoWCombatLog.txt files and should align as much as possible with in-game Skada-style results while also learning from uwu-logs parsing architecture.
+
+Primary objectives:
+1. Audit current parser.py and every code path that touches uploaded WoWCombatLog.txt files.
+2. Study uwu-logs and Skada-WoTLK as reference implementations.
+3. Refactor parser.py into clear, testable parsing modules if needed.
+4. Build a proper test suite before and during refactor.
+5. Preserve existing production functionality unless it is objectively wrong.
+6. Do not guess silently. Document assumptions.
+
+Must analyze and improve:
+- Total damage
+- Useful damage
+- DPS
+- Total healing
+- HPS
+- Overkill/overheal treatment, if available in log data
+- Pets/guardians attribution
+- Encounter start/end detection
+- Wipe detection
+- Kill detection
+- Multi-attempt sessions
+- Boss attempts where raid wipes on Heroic then switches to Normal
+- Bosses where difficulty changes mid-session
+- 10-man vs 25-man detection
+- Normal vs Heroic detection
+- Encounter ordering
+- Boss aliases / NPC ID handling
+- Trash vs boss segmentation
+- Partial logs
+- Duplicate uploads
+- Malformed or truncated lines
+- Unsupported lines should not crash parsing
+
+Reference behavior:
+- Use Skada-WoTLK to understand how in-game damage, healing, DPS, HPS, useful damage, and segment boundaries are typically represented.
+- Use uwu-logs to understand WotLK combat log parsing structure, boss detection, aura/event handling, and upload-oriented parsing.
+- Do not blindly copy code. Use both repos as validation references and architectural guidance.
+- Cite specific files/functions from the reference repos in internal notes or docs when their logic influences changes.
+
+Expected implementation approach:
+1. Create a working branch, for example:
+   parser-refactor-tdd
+
+2. Inspect current repo:
+   - parser.py
+   - upload handlers
+   - database write paths
+   - models/schema
+   - existing tests
+   - leaderboard calculations
+   - raid sessions page logic
+   - admin upload logic
+   - any docs describing parser assumptions
+
+3. Create a parser audit note before changing logic:
+   docs/parser-audit.md
+
+Include:
+   - current parser flow
+   - known weaknesses
+   - reference repo findings
+   - proposed target architecture
+   - risk areas
+   - test coverage plan
+
+4. Add or improve tests:
+   - Unit tests for individual combat log line parsing
+   - Unit tests for damage aggregation
+   - Unit tests for healing aggregation
+   - Unit tests for DPS/HPS windows
+   - Unit tests for encounter segmentation
+   - Unit tests for wipe vs kill detection
+   - Unit tests for heroic-to-normal fallback cases
+   - Unit tests for 10m/25m and normal/heroic detection
+   - Regression tests for any current known Pizza Logs bugs
+   - Fixture-based tests using small synthetic WoWCombatLog.txt samples
+   - If safe, add larger anonymized sample fixtures
+
+5. Parser architecture target:
+   Prefer separating responsibilities:
+   - raw line tokenizer
+   - event normalizer
+   - actor resolver
+   - spell/event classifier
+   - encounter detector
+   - difficulty detector
+   - attempt/session segmenter
+   - damage/healing aggregator
+   - metric calculator
+   - persistence adapter
+
+6. Metrics rules:
+   Damage:
+   - total_damage = all valid damage credited to actors during an encounter segment
+   - useful_damage = damage that meaningfully contributes to boss/encounter progress; exclude irrelevant padding where identifiable
+   - keep rules explicit and configurable because â€œusefulâ€ can be encounter-specific
+
+   DPS:
+   - calculate from encounter active duration
+   - avoid inflated DPS from full uploaded-file duration
+   - define whether player active time or encounter duration is used
+   - document the chosen rule
+
+   Healing:
+   - total_healing should distinguish raw healing vs effective healing if log data supports it
+   - overheal should not inflate effective healing if overheal fields are present
+   - HPS should use encounter duration unless existing app convention says otherwise
+
+7. Encounter/difficulty rules:
+   - Prefer explicit ENCOUNTER_START / ENCOUNTER_END where present.
+   - Warmane/WotLK logs may be inconsistent, so add fallback heuristics.
+   - Use boss NPC IDs, boss damage taken, boss death, raid combat state, and encounter boundaries as supporting signals.
+   - Correctly split attempts when a wipe occurs.
+   - Correctly treat a later normal kill after heroic wipes as a separate normal kill.
+   - Do not merge heroic wipes and normal kills into one result.
+   - Do not bucket normal attempts under heroic or heroic attempts under normal.
+   -
+
+[Truncated for vault import.]
+
+## Assistant
+
+Implemented and published the parser refactor on `codex-dev`.
+
+Draft PR: [#10 harden combat log parser flow](https://github.com/CRSD-Lau/Pizza-Logs/pull/10)
+Commit: `0cb9103 refactor: harden combat log parser flow`
+Branch status: clean, pushed to `origin/codex-dev`
+
+Main changes:
+- Added [docs/parser-audit.md](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/docs/parser-audit.md) with current flow, Skada/uwu reference findings, risks, assumptions, and test plan.
+- Added [parser/combat_log_events.py](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/parser/combat_log_events.py) for tokenizer/skipped-line handling.
+- Added [parser/combat_metrics.py](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/parser/combat_metrics.py) for damage/healing field extraction.
+- Refactored [parser/parser_core.py](C:/Users/neil_/OneDrive/Desktop/PizzaLogs/parser/parser_core.py) behind tests.
+- Fixed malformed-line reporting, short explicit-marker encounters, `/parse-stream` filename validation, and heroic-wipe-to-normal-kill difficulty bleed.
+- Updated README, parser contract docs, vault handoff/current focus, parser architecture, security checklist, decision log, and known issues.
+
+Validation passed:
+- Parser pytest: `133 passed, 1 warning`
+- TypeScript type-check
+- ESLint
+- Next production build
+- `git diff --check`
+- Staged secret scan: no matches
+
+Remaining risks are documented: absorbs still need separate implementation, useful damage needs more encounter-specific rules over time, and hard server-side upload size enforcement remains a follow-up.
+
+::git-stage{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-commit{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs"}
+::git-push{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev"}
+::git-create-pr{cwd="C:\Users\neil_\OneDrive\Desktop\PizzaLogs" branch="codex-dev" url="https://github.com/CRSD-Lau/Pizza-Logs/pull/10" isDraft=true}

--- a/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/Imported Codex Chats Index.md
+++ b/Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/Imported Codex Chats Index.md
@@ -1,0 +1,34 @@
+# Imported Codex Chats Index
+
+Imported on 2026-05-05 into the GitHub-backed Pizza Logs checkout at `C:\Projects\PizzaLogs`.
+
+These notes preserve the useful discussion history from local Codex session logs without committing raw JSONL, encrypted reasoning payloads, tool payloads, or local secret files.
+
+## Imported Chats
+
+| Date | Chat | Note |
+|---|---|---|
+| 2026-04-30 | Add native player gear | [2026-04-30 - add-native-player-gear.md](<2026-04-30 - add-native-player-gear.md>) |
+| 2026-04-30 | Fix relic offhand gearscore | [2026-04-30 - fix-relic-offhand-gearscore.md](<2026-04-30 - fix-relic-offhand-gearscore.md>) |
+| 2026-05-01 | Plan roster sync API | [2026-05-01 - plan-roster-sync-api.md](<2026-05-01 - plan-roster-sync-api.md>) |
+| 2026-05-03 | Query wow_items 50024 | [2026-05-03 - query-wow-items-50024.md](<2026-05-03 - query-wow-items-50024.md>) |
+| 2026-05-03 | Audit and clean Pizza Logs repo | [2026-05-03 - audit-and-clean-pizza-logs-repo.md](<2026-05-03 - audit-and-clean-pizza-logs-repo.md>) |
+| 2026-05-03 | Use this for favicon | [2026-05-03 - use-this-for-favicon.md](<2026-05-03 - use-this-for-favicon.md>) |
+| 2026-05-03 | Add character headshots | [2026-05-03 - add-character-headshots.md](<2026-05-03 - add-character-headshots.md>) |
+| 2026-05-03 | Add character headshots | [2026-05-03 - add-character-headshots-2.md](<2026-05-03 - add-character-headshots-2.md>) |
+| 2026-05-03 | Fix ICC boss ordering | [2026-05-03 - fix-icc-boss-ordering.md](<2026-05-03 - fix-icc-boss-ordering.md>) |
+| 2026-05-04 | Locate duplicate PizzaLogs folder | [2026-05-04 - locate-duplicate-pizzalogs-folder.md](<2026-05-04 - locate-duplicate-pizzalogs-folder.md>) |
+| 2026-05-04 | Add MVP animation pass | [2026-05-04 - add-mvp-animation-pass.md](<2026-05-04 - add-mvp-animation-pass.md>) |
+| 2026-05-04 | Add upload cinematic intro | [2026-05-04 - add-upload-cinematic-intro.md](<2026-05-04 - add-upload-cinematic-intro.md>) |
+| 2026-05-04 | Create cinematic landing animation | [2026-05-04 - create-cinematic-landing-animation.md](<2026-05-04 - create-cinematic-landing-animation.md>) |
+| 2026-05-04 | Set up test server correctly | [2026-05-04 - set-up-test-server-correctly.md](<2026-05-04 - set-up-test-server-correctly.md>) |
+| 2026-05-05 | Audit and clean docs | [2026-05-05 - audit-and-clean-docs.md](<2026-05-05 - audit-and-clean-docs.md>) |
+| 2026-05-05 | Refactor parser and upload flow | [2026-05-05 - refactor-parser-and-upload-flow.md](<2026-05-05 - refactor-parser-and-upload-flow.md>) |
+| 2026-05-05 | Move project to local GitHub | [2026-05-05 - move-project-to-local-github.md](<2026-05-05 - move-project-to-local-github.md>) |
+
+## Import Notes
+
+- Raw Codex logs remain outside the repo under `C:\Users\neil_\.codex\sessions`.
+- The imported notes keep user messages and assistant final replies.
+- Tool calls, command outputs, encrypted reasoning payloads, and `.env*` file contents are not imported.
+- Secret-like values are redacted during import.

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Docker compose is available for a local production-style stack:
 docker compose up --build
 ```
 
-On Neil's Windows desktop, the preferred local workflow is the two Desktop launchers:
+On Neil's Windows laptop, the preferred local workflow is the two launchers in the repo root:
 
 ```powershell
-C:\Users\neil_\OneDrive\Desktop\Start Pizza Logs Local.cmd
-C:\Users\neil_\OneDrive\Desktop\Stop Pizza Logs Local.cmd
+C:\Projects\PizzaLogs\Start Pizza Logs Local.cmd
+C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd
 ```
 
 The launchers call repo scripts that manage the local web app on `127.0.0.1:3001`, the parser on `127.0.0.1:8000`, and the local PostgreSQL service. They also keep the old repeating `PizzaLogsLocalTestServer` scheduled task disabled so PowerShell does not pop up every few minutes.

--- a/Start Pizza Logs Local.cmd
+++ b/Start Pizza Logs Local.cmd
@@ -1,0 +1,8 @@
+@echo off
+set "REPO=%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%scripts\start-local-test-server.ps1" -DisableScheduledTask
+if errorlevel 1 (
+  echo.
+  echo Start failed. See %REPO%.next-local-test-server.log for details.
+  pause
+)

--- a/Stop Pizza Logs Local.cmd
+++ b/Stop Pizza Logs Local.cmd
@@ -1,0 +1,8 @@
+@echo off
+set "REPO=%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%scripts\stop-local-test-server.ps1" -DisableScheduledTask -StopPostgres
+if errorlevel 1 (
+  echo.
+  echo Stop had errors. If PostgreSQL did not stop, right-click this script and choose Run as administrator.
+  pause
+)

--- a/scripts/desktop/Start Pizza Logs Local.cmd
+++ b/scripts/desktop/Start Pizza Logs Local.cmd
@@ -1,8 +1,0 @@
-@echo off
-set "REPO=C:\Projects\PizzaLogs"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\start-local-test-server.ps1" -DisableScheduledTask
-if errorlevel 1 (
-  echo.
-  echo Start failed. See %REPO%\.next-local-test-server.log for details.
-  pause
-)

--- a/scripts/desktop/Start Pizza Logs Local.cmd
+++ b/scripts/desktop/Start Pizza Logs Local.cmd
@@ -1,5 +1,5 @@
 @echo off
-set "REPO=C:\Users\neil_\OneDrive\Desktop\PizzaLogs"
+set "REPO=C:\Projects\PizzaLogs"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\start-local-test-server.ps1" -DisableScheduledTask
 if errorlevel 1 (
   echo.

--- a/scripts/desktop/Stop Pizza Logs Local.cmd
+++ b/scripts/desktop/Stop Pizza Logs Local.cmd
@@ -1,8 +1,0 @@
-@echo off
-set "REPO=C:\Projects\PizzaLogs"
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\stop-local-test-server.ps1" -DisableScheduledTask -StopPostgres
-if errorlevel 1 (
-  echo.
-  echo Stop had errors. If PostgreSQL did not stop, right-click this script and choose Run as administrator.
-  pause
-)

--- a/scripts/desktop/Stop Pizza Logs Local.cmd
+++ b/scripts/desktop/Stop Pizza Logs Local.cmd
@@ -1,5 +1,5 @@
 @echo off
-set "REPO=C:\Users\neil_\OneDrive\Desktop\PizzaLogs"
+set "REPO=C:\Projects\PizzaLogs"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%REPO%\scripts\stop-local-test-server.ps1" -DisableScheduledTask -StopPostgres
 if errorlevel 1 (
   echo.


### PR DESCRIPTION
## Summary
- retarget desktop launcher templates to C:\Projects\PizzaLogs
- document the local checkout migration in the vault handoff files
- keep the OneDrive checkout available as a fallback while local work moves to C:\Projects

## Validation
- npm ci --legacy-peer-deps
- npm run db:generate
- npm run type-check
- npm run lint
- npm run build
- parser\.venv\Scripts\python.exe -m pytest tests/ -v
- desktop Start launcher returns web/parser health on 127.0.0.1:3001 and 127.0.0.1:8000

## Notes
PostgreSQL service postgresql-x64-16 is stopped locally and needs an elevated start if DB-backed routes return 500.