### PR TITLE
ci: notify Slack for pull requests

### DIFF
--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -1,0 +1,131 @@
+name: PR Slack Notify
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Send pull request summary to Slack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post PR details
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.PR_SLACK_WEBHOOK_URL }}
+        with:
+          script: |
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+            if (!webhookUrl) {
+              core.setFailed("Missing PR_SLACK_WEBHOOK_URL repository secret for the #pull-requests Slack webhook.");
+              return;
+            }
+
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const action = context.payload.action.replace(/_/g, " ");
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const maxFiles = 25;
+            const fileSummary = files
+              .slice(0, maxFiles)
+              .map((file) => `- ${file.status}: \`${file.filename}\` (+${file.additions}/-${file.deletions})`)
+              .join("\n");
+            const fileOverflow = files.length > maxFiles
+              ? `\n- ...and ${files.length - maxFiles} more file(s)`
+              : "";
+
+            const body = (pr.body || "_No PR description provided._").trim();
+            const bodyLimit = 2400;
+            const safeBody = body
+              .replace(/@(channel|here|everyone)/gi, "@\u200b$1")
+              .slice(0, bodyLimit);
+            const bodySuffix = body.length > bodyLimit ? "\n\n_Description truncated in Slack. Open the PR for the full text._" : "";
+
+            const base = pr.base.ref;
+            const head = pr.head.ref;
+            const draftLabel = pr.draft ? "Draft" : "Ready";
+            const reviewUrl = `${pr.html_url}/files`;
+            const checksUrl = `${pr.html_url}/checks`;
+
+            const headerMarkdown = [
+              `*Pull request ${action}: <${pr.html_url}|#${pr.number} ${pr.title}>*`,
+              `*State:* ${draftLabel}`,
+              `*Author:* ${pr.user.login}`,
+              `*Branch:* \`${head}\` -> \`${base}\``,
+              `*Changed files:* ${files.length}`,
+              `*Review:* <${reviewUrl}|Files changed> | <${checksUrl}|Checks>`,
+            ].join("\n");
+
+            const bodyMarkdown = [
+              "",
+              "*PR Description*",
+              safeBody + bodySuffix,
+            ].join("\n");
+
+            const filesMarkdown = [
+              "",
+              "*Changed Files*",
+              fileSummary || "_No files reported by GitHub yet._",
+              fileOverflow,
+            ].join("\n");
+
+            const section = (text) => ({
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: text.slice(0, 3000),
+              },
+            });
+
+            const response = await fetch(webhookUrl, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                text: `Pizza Logs PR #${pr.number}: ${pr.title}`,
+                unfurl_links: false,
+                unfurl_media: false,
+                blocks: [
+                  section(headerMarkdown),
+                  section(bodyMarkdown),
+                  section(filesMarkdown),
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {
+                          type: "plain_text",
+                          text: "Open PR",
+                        },
+                        url: pr.html_url,
+                      },
+                      {
+                        type: "button",
+                        text: {
+                          type: "plain_text",
+                          text: "Review Diff",
+                        },
+                        url: reviewUrl,
+                      },
+                    ],
+                  },
+                ],
+              }),
+            });
+
+            if (!response.ok) {
+              const details = await response.text();
+              core.setFailed(`Slack webhook rejected the PR notification: ${response.status} ${details}`);
+            }

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -97,6 +97,7 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 - Slack messages include the PR title, author, draft/ready state, source/target branches, changed-file count, PR description, changed-file summary, and buttons linking to the PR and diff.
 - Documented the required `PR_SLACK_WEBHOOK_URL` repository secret in `docs/git-workflow.md`.
 - The secret must contain a Slack incoming webhook configured for the Codex Slack server's `#pull-requests` channel.
+- Opened PR #12 from `codex-dev` into `main` for this workflow.
 
 ## Remaining Risks
 
@@ -108,4 +109,4 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 
 ## Exact Next Step
 
-Add the `PR_SLACK_WEBHOOK_URL` repository secret for the Codex Slack `#pull-requests` incoming webhook, then review the PR from `codex-dev` into `main`. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Add the `PR_SLACK_WEBHOOK_URL` repository secret for the Codex Slack `#pull-requests` incoming webhook, then review PR #12 from `codex-dev` into `main`. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -28,6 +28,7 @@
 ## Current Implementation Snapshot
 
 - Next.js app has public pages for upload, raids, sessions, encounters, bosses, leaderboards, players, guild roster, and weekly stats.
+- GitHub Actions posts new, reopened, and ready-for-review PR summaries to Slack when `PR_SLACK_WEBHOOK_URL` is configured for the Codex Slack `#pull-requests` channel.
 - `/uploads` and `/uploads/[id]` redirect to admin upload history; public raid/session pages use `/raids/...`.
 - `/admin`, `/admin/uploads`, cleanup actions, and admin import APIs are protected by `ADMIN_SECRET`.
 - Upload flow streams multipart data from `app/api/upload/route.ts` to parser `/parse-stream`, then writes database rows and milestones.
@@ -89,13 +90,22 @@ PowerShell/npm shims in `node_modules/.bin` hit OneDrive reparse-point `Access i
 - Imported notes keep user messages and assistant final replies, while omitting raw JSONL, tool payloads, encrypted reasoning payloads, and `.env*` contents.
 - Secret-like values were redacted during import, and the imported vault notes were checked with `git grep --untracked` for obvious database URLs, tokens, and private-key patterns.
 
+## PR Slack Notification This Session
+
+- Added `.github/workflows/pr-slack-notify.yml`.
+- The workflow uses `pull_request_target` for `opened`, `reopened`, and `ready_for_review` events without checking out or executing PR branch code.
+- Slack messages include the PR title, author, draft/ready state, source/target branches, changed-file count, PR description, changed-file summary, and buttons linking to the PR and diff.
+- Documented the required `PR_SLACK_WEBHOOK_URL` repository secret in `docs/git-workflow.md`.
+- The secret must contain a Slack incoming webhook configured for the Codex Slack server's `#pull-requests` channel.
+
 ## Remaining Risks
 
 - Absorbs are still not implemented as healing; Skada treats them separately.
 - Some Warmane heroic/Gunship evidence is not present in every log, so ambiguous attempts stay conservative rather than guessed heroic.
 - Useful damage is documented and test-covered through existing encounter rules, but needs more encounter-specific exclusions over time.
 - Upload route still lacks hard server-side size enforcement; this remains the highest practical upload-flow follow-up.
+- PR Slack notifications will fail until `PR_SLACK_WEBHOOK_URL` is added as a GitHub repository secret for `#pull-requests`.
 
 ## Exact Next Step
 
-Review draft PR #11 from `codex-dev` into `main` for the local checkout migration. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Add the `PR_SLACK_WEBHOOK_URL` repository secret for the Codex Slack `#pull-requests` incoming webhook, then review the PR from `codex-dev` into `main`. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -13,6 +13,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Added a GitHub Actions PR Slack notification workflow for `opened`, `reopened`, and `ready_for_review` pull request events.
 - The Slack message includes PR metadata, description markdown, changed-file summary, and direct links to the PR and file diff.
 - Documented that GitHub needs a `PR_SLACK_WEBHOOK_URL` repository secret pointing at the Codex Slack server's `#pull-requests` incoming webhook.
+- Opened PR #12 from `codex-dev` into `main` for the Slack notification workflow.
 - Created `docs/parser-audit.md` before changing parser behavior.
 - Audited parser and upload code paths, including `/parse-stream`, parser core, persistence contracts, docs, and current tests.
 - Studied local checkouts of `Ridepad/uwu-logs` and `bkader/Skada-WoTLK`; audit notes cite the relevant files/functions.
@@ -50,7 +51,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
 | Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers live in repo root |
 | Codex chat import | DONE | 17 readable vault digests under `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/` |
-| PR Slack notification | DONE | Workflow added; waits on `PR_SLACK_WEBHOOK_URL` repository secret |
+| PR Slack notification | DONE | Workflow added in PR #12; waits on `PR_SLACK_WEBHOOK_URL` repository secret |
 | Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
 | PR update | DONE | Draft PR #11 opened from `codex-dev` into `main` |
 

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -10,6 +10,9 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Added a GitHub Actions PR Slack notification workflow for `opened`, `reopened`, and `ready_for_review` pull request events.
+- The Slack message includes PR metadata, description markdown, changed-file summary, and direct links to the PR and file diff.
+- Documented that GitHub needs a `PR_SLACK_WEBHOOK_URL` repository secret pointing at the Codex Slack server's `#pull-requests` incoming webhook.
 - Created `docs/parser-audit.md` before changing parser behavior.
 - Audited parser and upload code paths, including `/parse-stream`, parser core, persistence contracts, docs, and current tests.
 - Studied local checkouts of `Ridepad/uwu-logs` and `bkader/Skada-WoTLK`; audit notes cite the relevant files/functions.
@@ -47,11 +50,13 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Validation | DONE | Parser tests, type-check, lint, build, diff check |
 | Local checkout migration | DONE | `C:\Projects\PizzaLogs` validated; launchers live in repo root |
 | Codex chat import | DONE | 17 readable vault digests under `Pizza Logs HQ/08 AI Control Center/Imported Codex Chats/` |
+| PR Slack notification | DONE | Workflow added; waits on `PR_SLACK_WEBHOOK_URL` repository secret |
 | Branch publication | DONE | Local checkout migration committed and ready to push on `codex-dev` |
 | PR update | DONE | Draft PR #11 opened from `codex-dev` into `main` |
 
 ## Open Follow-Ups
 
+- Add the GitHub repository secret `PR_SLACK_WEBHOOK_URL` with a Slack incoming webhook configured for `#pull-requests`.
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -75,6 +75,8 @@ Open a PR:
 codex-dev -> main
 ```
 
+GitHub Actions posts new, reopened, and ready-for-review pull requests to the Codex Slack server's `#pull-requests` channel through `.github/workflows/pr-slack-notify.yml`. The repository must have a `PR_SLACK_WEBHOOK_URL` secret whose Slack incoming webhook is configured for `#pull-requests`; do not commit the webhook URL to the repo.
+
 ## After Merge
 
 After Neil merges the PR, update `codex-dev` from `main` before new work:


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that posts pull request summaries to the Codex Slack server's `#pull-requests` channel.
- Include PR title, author, draft/ready state, branch path, changed-file count, PR description markdown, changed-file summary, and links to the PR and file diff.
- Document the required `PR_SLACK_WEBHOOK_URL` repository secret.

## Validation

- `git diff --check` passed.
- Workflow syntax was reviewed locally; `actionlint` is not installed in this checkout.
- No parser or app runtime code changed.

## Setup Needed After Merge

Add the GitHub repository secret `PR_SLACK_WEBHOOK_URL` with a Slack incoming webhook configured for `#pull-requests`.

@codex review focus on GitHub Actions safety, secret handling, Slack payload formatting, and documentation drift.