### PR TITLE
Test PR Slack notification workflow

### DIFF
--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -37,49 +37,43 @@ jobs:
               per_page: 100,
             });
 
-            const maxFiles = 25;
+            const maxFiles = 12;
+            const statusLabels = {
+              added: "Added",
+              modified: "Modified",
+              removed: "Removed",
+              renamed: "Renamed",
+              copied: "Copied",
+              changed: "Changed",
+              unchanged: "Unchanged",
+            };
+
             const fileSummary = files
               .slice(0, maxFiles)
-              .map((file) => `- ${file.status}: \`${file.filename}\` (+${file.additions}/-${file.deletions})`)
+              .map((file) => {
+                const status = statusLabels[file.status] || file.status;
+                return `- *${status}* \`${file.filename}\`  +${file.additions} / -${file.deletions}`;
+              })
               .join("\n");
             const fileOverflow = files.length > maxFiles
-              ? `\n- ...and ${files.length - maxFiles} more file(s)`
+              ? `\n- _${files.length - maxFiles} more file(s) in the PR_`
               : "";
 
             const body = (pr.body || "_No PR description provided._").trim();
-            const bodyLimit = 2400;
+            const bodyLimit = 1200;
             const safeBody = body
               .replace(/@(channel|here|everyone)/gi, "@\u200b$1")
               .slice(0, bodyLimit);
-            const bodySuffix = body.length > bodyLimit ? "\n\n_Description truncated in Slack. Open the PR for the full text._" : "";
+            const bodySuffix = body.length > bodyLimit
+              ? "\n\n_Description trimmed. Open the PR for the full text._"
+              : "";
 
             const base = pr.base.ref;
             const head = pr.head.ref;
             const draftLabel = pr.draft ? "Draft" : "Ready";
             const reviewUrl = `${pr.html_url}/files`;
             const checksUrl = `${pr.html_url}/checks`;
-
-            const headerMarkdown = [
-              `*Pull request ${action}: <${pr.html_url}|#${pr.number} ${pr.title}>*`,
-              `*State:* ${draftLabel}`,
-              `*Author:* ${pr.user.login}`,
-              `*Branch:* \`${head}\` -> \`${base}\``,
-              `*Changed files:* ${files.length}`,
-              `*Review:* <${reviewUrl}|Files changed> | <${checksUrl}|Checks>`,
-            ].join("\n");
-
-            const bodyMarkdown = [
-              "",
-              "*PR Description*",
-              safeBody + bodySuffix,
-            ].join("\n");
-
-            const filesMarkdown = [
-              "",
-              "*Changed Files*",
-              fileSummary || "_No files reported by GitHub yet._",
-              fileOverflow,
-            ].join("\n");
+            const actionLabel = action.charAt(0).toUpperCase() + action.slice(1);
 
             const section = (text) => ({
               type: "section",
@@ -89,39 +83,74 @@ jobs:
               },
             });
 
+            const blocks = [
+              {
+                type: "header",
+                text: {
+                  type: "plain_text",
+                  text: `PR #${pr.number}: ${pr.title}`.slice(0, 150),
+                },
+              },
+              {
+                type: "context",
+                elements: [
+                  {
+                    type: "mrkdwn",
+                    text: `*${actionLabel}* by *${pr.user.login}* | *${draftLabel}* | \`${head}\` -> \`${base}\``,
+                  },
+                ],
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: `*Files changed*\n${files.length}` },
+                  { type: "mrkdwn", text: `*Checks*\n<${checksUrl}|View checks>` },
+                  { type: "mrkdwn", text: `*Diff*\n<${reviewUrl}|Files changed>` },
+                  { type: "mrkdwn", text: `*State*\n${draftLabel}` },
+                ],
+              },
+              section(`*Description*\n${safeBody + bodySuffix}`),
+              section(`*Changed files*\n${fileSummary || "_No files reported by GitHub yet._"}${fileOverflow}`),
+              {
+                type: "actions",
+                elements: [
+                  {
+                    type: "button",
+                    text: {
+                      type: "plain_text",
+                      text: "Open PR",
+                    },
+                    style: "primary",
+                    url: pr.html_url,
+                  },
+                  {
+                    type: "button",
+                    text: {
+                      type: "plain_text",
+                      text: "Review Diff",
+                    },
+                    url: reviewUrl,
+                  },
+                ],
+              },
+            ];
+
+            const fallbackText = [
+              `Pizza Logs PR #${pr.number}: ${pr.title}`,
+              `${actionLabel} by ${pr.user.login} | ${draftLabel} | ${head} -> ${base}`,
+              `${files.length} changed file(s)`,
+              pr.html_url,
+            ].join("\n");
+
             const response = await fetch(webhookUrl, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                text: `Pizza Logs PR #${pr.number}: ${pr.title}`,
+                text: fallbackText,
                 unfurl_links: false,
                 unfurl_media: false,
-                blocks: [
-                  section(headerMarkdown),
-                  section(bodyMarkdown),
-                  section(filesMarkdown),
-                  {
-                    type: "actions",
-                    elements: [
-                      {
-                        type: "button",
-                        text: {
-                          type: "plain_text",
-                          text: "Open PR",
-                        },
-                        url: pr.html_url,
-                      },
-                      {
-                        type: "button",
-                        text: {
-                          type: "plain_text",
-                          text: "Review Diff",
-                        },
-                        url: reviewUrl,
-                      },
-                    ],
-                  },
-                ],
+                blocks,
               }),
             });
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -74,6 +74,7 @@
 - Added `docs/dev/TOOLING.md` and linked it from the README Local Development section.
 - Railway CLI is present, but this checkout is not linked; no Railway deploy or link was performed.
 - Added a tiny docs-only PR notification test note to `docs/dev/TOOLING.md` after Neil configured `PR_SLACK_WEBHOOK_URL`, so a fresh pull request can trigger the Slack workflow.
+- Cleaned up `.github/workflows/pr-slack-notify.yml` Slack blocks after the test message proved too raw: compact header/context, metadata fields, trimmed description, shorter changed-file list, and ASCII-safe separators.
 
 ## Verification This Session
 
@@ -89,6 +90,7 @@
 | `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
 | `npm run build` from clean `.next` | Passed |
 | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\verify-tooling.ps1` | Passed with 0 failures; 1 expected Railway-unlinked warning |
+| `git diff --check` after Slack workflow formatting cleanup | Passed |
 
 ## Remaining Risks
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -73,6 +73,7 @@
   - `scripts/dev/verify-tooling.ps1`
 - Added `docs/dev/TOOLING.md` and linked it from the README Local Development section.
 - Railway CLI is present, but this checkout is not linked; no Railway deploy or link was performed.
+- Added a tiny docs-only PR notification test note to `docs/dev/TOOLING.md` after Neil configured `PR_SLACK_WEBHOOK_URL`, so a fresh pull request can trigger the Slack workflow.
 
 ## Verification This Session
 
@@ -100,4 +101,4 @@
 
 ## Exact Next Step
 
-Review PR #13 from `codex-dev` into `main`. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Open/review the docs-only PR notification test from `codex-dev` into `main` and confirm the Slack webhook posts to the configured channel. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -10,6 +10,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Added a tiny docs-only PR notification test note after Neil configured `PR_SLACK_WEBHOOK_URL`, so opening a fresh `codex-dev` to `main` PR can test the Slack webhook.
 - Audited local Windows tooling for PowerShell, WinGet, Git/GitHub, Node/npm/npx, pnpm/yarn, Python/pip, search/JSON tools, curl/tar/ssh, Railway, Vercel, Codex CLI, VS Code CLI, Windows Terminal, repo scripts, GitHub auth, and Railway link state.
 - Installed PowerShell 7.6.1 with WinGet.
 - Installed standalone `ripgrep`, `fd`, and `jq` with WinGet.
@@ -53,11 +54,12 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Slack notification fail-open | DONE | Missing webhook secret now warns and exits successfully |
 | Windows tooling setup docs/scripts | DONE | `scripts/dev/setup-tooling.ps1`, `scripts/dev/verify-tooling.ps1`, `docs/dev/TOOLING.md` |
 | Tooling verification | DONE | Passed with 0 failures; Railway remains unlinked by design |
+| Slack webhook test PR | IN PROGRESS | Docs-only change prepared for a fresh PR event |
 
 ## Open Follow-Ups
 
 - Smoke-check the intro on real iPhone Safari and Android Chrome after the PR is deployed.
-- Add the GitHub repository secret `PR_SLACK_WEBHOOK_URL` with a Slack incoming webhook configured for `#pull-requests` if Slack notifications are desired.
+- Confirm the fresh docs-only PR posts to Slack now that `PR_SLACK_WEBHOOK_URL` is configured.
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -11,6 +11,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 ## This Session
 
 - Added a tiny docs-only PR notification test note after Neil configured `PR_SLACK_WEBHOOK_URL`, so opening a fresh `codex-dev` to `main` PR can test the Slack webhook.
+- Cleaned up the PR Slack message formatting after the test notification was too dense/raw.
 - Audited local Windows tooling for PowerShell, WinGet, Git/GitHub, Node/npm/npx, pnpm/yarn, Python/pip, search/JSON tools, curl/tar/ssh, Railway, Vercel, Codex CLI, VS Code CLI, Windows Terminal, repo scripts, GitHub auth, and Railway link state.
 - Installed PowerShell 7.6.1 with WinGet.
 - Installed standalone `ripgrep`, `fd`, and `jq` with WinGet.
@@ -55,6 +56,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Windows tooling setup docs/scripts | DONE | `scripts/dev/setup-tooling.ps1`, `scripts/dev/verify-tooling.ps1`, `docs/dev/TOOLING.md` |
 | Tooling verification | DONE | Passed with 0 failures; Railway remains unlinked by design |
 | Slack webhook test PR | IN PROGRESS | Docs-only change prepared for a fresh PR event |
+| Slack message formatting cleanup | DONE | Workflow now uses compact Slack blocks and cleaner changed-file formatting |
 
 ## Open Follow-Ups
 

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -46,6 +46,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Cinematic intro audio was missing | Render scripts preserve audio tracks, and the intro overlay now has a sound toggle while still starting muted for autoplay |
 | Missing PR Slack webhook failed PR checks | Workflow now warns and exits successfully when `PR_SLACK_WEBHOOK_URL` is absent |
 | Local `rg` resolved to Codex app bundle and failed with Access denied | Installed standalone `ripgrep` with WinGet and prioritized its package directory in User PATH via `scripts/dev/setup-tooling.ps1` |
+| PR Slack message read like a raw dump | Reworked Slack blocks into a compact header, metadata fields, trimmed description, and cleaner changed-file list |
 
 ## Not Bugs
 

--- a/docs/dev/TOOLING.md
+++ b/docs/dev/TOOLING.md
@@ -105,3 +105,5 @@ C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd
 The verification script may run `railway status`, but it never deploys. Do not run deploy commands unless Neil explicitly asks.
 
 Production deploys from `origin/main` after Neil merges a PR. Codex works on `codex-dev`, opens PRs into `main`, and does not push or merge `main` directly.
+
+GitHub PR Slack notifications are tested by opening a normal `codex-dev` to `main` pull request after `PR_SLACK_WEBHOOK_URL` is configured as a repository Actions secret.


### PR DESCRIPTION
## Summary
- Add a tiny docs-only note explaining how to test PR Slack notifications after PR_SLACK_WEBHOOK_URL is configured.
- Update the vault handoff/focus notes for this test PR.

## Purpose
This PR is intentionally small so we can confirm the GitHub Actions Slack webhook posts for a fresh codex-dev -> main pull request.

## Verification
- git diff --check

## Notes
- No Railway deploy was run.
- No secrets are included.