### PR TITLE
Normalize PR markdown for Slack notifications

### DIFF
--- a/.github/workflows/pr-slack-notify.yml
+++ b/.github/workflows/pr-slack-notify.yml
@@ -61,10 +61,15 @@ jobs:
 
             const body = (pr.body || "_No PR description provided._").trim();
             const bodyLimit = 1200;
-            const safeBody = body
+            const formatDescriptionForSlack = (text) => text
               .replace(/@(channel|here|everyone)/gi, "@\u200b$1")
-              .slice(0, bodyLimit);
-            const bodySuffix = body.length > bodyLimit
+              .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
+              .replace(/^\s*[-*]\s+/gm, "- ")
+              .replace(/\n{3,}/g, "\n\n")
+              .trim();
+            const formattedBody = formatDescriptionForSlack(body);
+            const safeBody = formattedBody.slice(0, bodyLimit);
+            const bodySuffix = formattedBody.length > bodyLimit
               ? "\n\n_Description trimmed. Open the PR for the full text._"
               : "";
 

--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -75,6 +75,7 @@
 - Railway CLI is present, but this checkout is not linked; no Railway deploy or link was performed.
 - Added a tiny docs-only PR notification test note to `docs/dev/TOOLING.md` after Neil configured `PR_SLACK_WEBHOOK_URL`, so a fresh pull request can trigger the Slack workflow.
 - Cleaned up `.github/workflows/pr-slack-notify.yml` Slack blocks after the test message proved too raw: compact header/context, metadata fields, trimmed description, shorter changed-file list, and ASCII-safe separators.
+- Normalized GitHub PR description markdown for Slack by converting markdown headings to bold labels and collapsing noisy whitespace.
 
 ## Verification This Session
 
@@ -98,6 +99,7 @@
 - Local visual validation covered desktop in the in-app browser plus extracted mobile frames; test devices should still smoke-check iPhone Safari and Android Chrome after deployment.
 - Upload route still lacks hard server-side size enforcement.
 - PR Slack notifications still require `PR_SLACK_WEBHOOK_URL` in GitHub repository secrets, but missing configuration no longer fails PR checks.
+- `pull_request_target` runs the Slack workflow from `main`, so Slack formatting changes only affect fresh PR events after the workflow update is merged.
 - Absorbs remain future parser work.
 - Railway CLI is installed locally but this checkout remains unlinked until Neil intentionally runs `railway link`.
 

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -12,6 +12,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 - Added a tiny docs-only PR notification test note after Neil configured `PR_SLACK_WEBHOOK_URL`, so opening a fresh `codex-dev` to `main` PR can test the Slack webhook.
 - Cleaned up the PR Slack message formatting after the test notification was too dense/raw.
+- Adjusted PR description formatting for Slack so GitHub headings render as bold section labels instead of unsupported raw markdown.
 - Audited local Windows tooling for PowerShell, WinGet, Git/GitHub, Node/npm/npx, pnpm/yarn, Python/pip, search/JSON tools, curl/tar/ssh, Railway, Vercel, Codex CLI, VS Code CLI, Windows Terminal, repo scripts, GitHub auth, and Railway link state.
 - Installed PowerShell 7.6.1 with WinGet.
 - Installed standalone `ripgrep`, `fd`, and `jq` with WinGet.
@@ -57,6 +58,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Tooling verification | DONE | Passed with 0 failures; Railway remains unlinked by design |
 | Slack webhook test PR | IN PROGRESS | Docs-only change prepared for a fresh PR event |
 | Slack message formatting cleanup | DONE | Workflow now uses compact Slack blocks and cleaner changed-file formatting |
+| Slack markdown normalization | DONE | PR description headings convert to Slack-friendly bold labels |
 
 ## Open Follow-Ups
 

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -47,6 +47,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Missing PR Slack webhook failed PR checks | Workflow now warns and exits successfully when `PR_SLACK_WEBHOOK_URL` is absent |
 | Local `rg` resolved to Codex app bundle and failed with Access denied | Installed standalone `ripgrep` with WinGet and prioritized its package directory in User PATH via `scripts/dev/setup-tooling.ps1` |
 | PR Slack message read like a raw dump | Reworked Slack blocks into a compact header, metadata fields, trimmed description, and cleaner changed-file list |
+| PR description headings showed unsupported Slack markdown | Added markdown normalization so GitHub headings become Slack bold labels |
 
 ## Not Bugs
 


### PR DESCRIPTION
*Summary*
- Normalize GitHub PR description markdown before sending Slack notifications.
- Convert markdown headings into Slack-friendly bold labels.
- Collapse noisy whitespace and keep mention escaping.

*Why*
The Slack test message still showed raw GitHub Markdown because `pull_request_target` used the workflow from `main`, and the PR description body needed mrkdwn normalization.

*Verification*
- git diff --check

*Notes*
- No Railway deploy was run.
- No secrets are included.