### PR TITLE
[codex] Paginate guild roster table

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -26,6 +26,7 @@
 ## Current Implementation Snapshot
 
 - Next.js app has public pages for upload, raids, sessions, encounters, bosses, leaderboards, players, guild roster, and weekly stats.
+- `/guild-roster` now keeps the roster table contained to 20 members per page, with URL-backed page navigation in the table footer.
 - GitHub Actions posts new, reopened, and ready-for-review PR summaries to Slack when `PR_SLACK_WEBHOOK_URL` is configured; if the secret is missing, the workflow warns and exits successfully.
 - `/uploads` and `/uploads/[id]` redirect to admin upload history; public raid/session pages use `/raids/...`.
 - `/admin`, `/admin/uploads`, cleanup actions, and admin import APIs are protected by `ADMIN_SECRET`.
@@ -60,6 +61,14 @@
 - Removed obsolete `public/intro/` generated assets.
 - Updated README, `docs/intro-animation.md`, `AGENTS.md`, `.gitignore`, source tests, and vault notes.
 
+## Guild Roster Pagination Session
+
+- Updated the public guild roster page to read `?page=` and pass the current page into the roster table.
+- Limited the roster table to 20 visible members per page.
+- Kept the table inside a bordered panel with a footer navigator in the bottom-right area.
+- Added previous/next icon navigation with accessible labels and stable `/guild-roster?page=N` links.
+- Updated the guild roster render test to prove page 1 shows rows 1-20 and page 2 shows rows 21-25 for a 25-member roster.
+
 ## Windows Tooling Session
 
 - Audited Neil's local Windows development tooling from `C:\Projects\PizzaLogs`.
@@ -92,6 +101,11 @@
 | `npm run build` from clean `.next` | Passed |
 | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\dev\verify-tooling.ps1` | Passed with 0 failures; 1 expected Railway-unlinked warning |
 | `git diff --check` after Slack workflow formatting cleanup | Passed |
+| Guild roster render test with JSX-aware `ts-node` registration | Passed |
+| `node node_modules\typescript\bin\tsc --noEmit` | Passed |
+| `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
+| `npm run build` | Passed |
+| Local `GET http://127.0.0.1:3001/guild-roster?page=2` | Passed with HTTP 200 after dev server compile |
 
 ## Remaining Risks
 
@@ -105,4 +119,4 @@
 
 ## Exact Next Step
 
-Open/review the docs-only PR notification test from `codex-dev` into `main` and confirm the Slack webhook posts to the configured channel. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR after the guild roster pagination commit is pushed. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session added repeatable Windows development tooling setup and verification. Parser reliability remains the highest-risk product area, but no parser code changed in this session.
+The current session added guild roster pagination so the public roster shows 20 members per page inside a contained table panel. Parser reliability remains the highest-risk product area, but no parser code changed in this session.
 
 ## Current Branch Rule
 
@@ -10,6 +10,15 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Added URL-backed `?page=` handling on `/guild-roster`.
+- Updated `GuildRosterTable` to show 20 members per page.
+- Added a contained table panel footer with bottom-right previous/next page navigation.
+- Updated `tests/guild-roster-table-render.test.ts` to cover 25-member pagination across page 1 and page 2.
+- Ran the focused guild roster render test with JSX-aware `ts-node` registration; it passed.
+- Ran `node node_modules\typescript\bin\tsc --noEmit`; it passed.
+- Ran `node node_modules\eslint\bin\eslint.js . --max-warnings=0`; it passed.
+- Ran `npm run build`; it passed.
+- Confirmed the existing local dev server at `http://127.0.0.1:3001` served `/guild-roster?page=2` with HTTP 200 after compiling.
 - Added a tiny docs-only PR notification test note after Neil configured `PR_SLACK_WEBHOOK_URL`, so opening a fresh `codex-dev` to `main` PR can test the Slack webhook.
 - Cleaned up the PR Slack message formatting after the test notification was too dense/raw.
 - Adjusted PR description formatting for Slack so GitHub headings render as bold section labels instead of unsupported raw markdown.
@@ -59,6 +68,9 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Slack webhook test PR | IN PROGRESS | Docs-only change prepared for a fresh PR event |
 | Slack message formatting cleanup | DONE | Workflow now uses compact Slack blocks and cleaner changed-file formatting |
 | Slack markdown normalization | DONE | PR description headings convert to Slack-friendly bold labels |
+| Guild roster 20-member pages | DONE | `/guild-roster?page=N` controls the visible roster slice |
+| Roster table footer navigator | DONE | Previous/next icon links render in the table container footer |
+| Guild roster render coverage | DONE | Test covers page 1 and page 2 slicing |
 
 ## Open Follow-Ups
 

--- a/app/guild-roster/page.tsx
+++ b/app/guild-roster/page.tsx
@@ -5,7 +5,19 @@ import { DEFAULT_GUILD_NAME, DEFAULT_GUILD_REALM, readGuildRosterMembers } from 
 export const metadata: Metadata = { title: "Guild Roster" };
 export const dynamic = "force-dynamic";
 
-export default async function GuildRosterPage() {
+interface Props {
+  searchParams: Promise<{ page?: string | string[] }>;
+}
+
+function parseRosterPage(value: string | string[] | undefined): number {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  const parsed = Number(rawValue);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+export default async function GuildRosterPage({ searchParams }: Props) {
+  const { page } = await searchParams;
+  const currentPage = parseRosterPage(page);
   const members = await readGuildRosterMembers(DEFAULT_GUILD_NAME, DEFAULT_GUILD_REALM);
   const latestSync = members.reduce<Date | null>((latest, member) => {
     if (!latest || member.lastSyncedAt > latest) return member.lastSyncedAt;
@@ -28,7 +40,7 @@ export default async function GuildRosterPage() {
         </p>
       </div>
 
-      <GuildRosterTable members={members} />
+      <GuildRosterTable members={members} currentPage={currentPage} />
     </div>
   );
 }

--- a/components/guild-roster/GuildRosterTable.tsx
+++ b/components/guild-roster/GuildRosterTable.tsx
@@ -1,8 +1,12 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { PlayerAvatar } from "../players/PlayerAvatar";
 import { getClassColor } from "../../lib/constants/classes";
 import { getRevealClassName, getRevealStyle } from "../../lib/ui-animation";
 import { getClassIconUrl } from "../../lib/class-icons";
+
+const GUILD_ROSTER_PAGE_SIZE = 20;
 
 export type GuildRosterTableMember = {
   id: string;
@@ -22,6 +26,11 @@ export type GuildRosterTableMember = {
   lastSyncedAt: Date;
   createdAt: Date;
   updatedAt: Date;
+};
+
+type GuildRosterTableProps = {
+  members: GuildRosterTableMember[];
+  currentPage?: number;
 };
 
 function formatSyncedAt(value: Date): string {
@@ -49,7 +58,54 @@ function formatProfessions(value: unknown): string {
   return professions.length > 0 ? professions.join(", ") : "-";
 }
 
-export function GuildRosterTable({ members }: { members: GuildRosterTableMember[] }) {
+function getPageHref(page: number): string {
+  return page <= 1 ? "/guild-roster" : `/guild-roster?page=${page}`;
+}
+
+function clampPage(page: number, totalPages: number): number {
+  if (!Number.isFinite(page)) return 1;
+  return Math.min(Math.max(Math.trunc(page), 1), totalPages);
+}
+
+function PageNavButton({
+  href,
+  label,
+  disabled,
+  children,
+}: {
+  href: string;
+  label: string;
+  disabled: boolean;
+  children: ReactNode;
+}) {
+  const className =
+    "inline-flex h-8 w-8 items-center justify-center rounded-sm border border-gold-dim text-text-secondary transition-colors";
+
+  if (disabled) {
+    return (
+      <span
+        aria-disabled="true"
+        className={`${className} cursor-not-allowed opacity-40`}
+        title={label}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      className={`${className} hover:border-gold/60 hover:text-gold-light`}
+      title={label}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function GuildRosterTable({ members, currentPage = 1 }: GuildRosterTableProps) {
   if (members.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
@@ -61,81 +117,119 @@ export function GuildRosterTable({ members }: { members: GuildRosterTableMember[
     );
   }
 
-  return (
-    <div className="overflow-x-auto border border-gold-dim bg-bg-panel rounded">
-      <table className="min-w-full text-sm">
-        <thead className="bg-bg-card text-text-dim">
-          <tr className="text-left text-[11px] uppercase tracking-widest">
-            <th className="px-4 py-3 font-semibold">Character</th>
-            <th className="px-4 py-3 font-semibold">Class</th>
-            <th className="px-4 py-3 font-semibold">Race</th>
-            <th className="px-4 py-3 font-semibold">Level</th>
-            <th className="px-4 py-3 font-semibold">Rank</th>
-            <th className="px-4 py-3 font-semibold">GS</th>
-            <th className="px-4 py-3 font-semibold">Professions</th>
-            <th className="px-4 py-3 font-semibold">Guild</th>
-            <th className="px-4 py-3 font-semibold">Realm</th>
-            <th className="px-4 py-3 font-semibold">Last Synced</th>
-            <th className="px-4 py-3 font-semibold text-right">Profile</th>
-          </tr>
-        </thead>
-        <tbody>
-          {members.map((member, index) => {
-            const classColor = getClassColor(member.className ?? member.characterName);
+  const totalPages = Math.max(1, Math.ceil(members.length / GUILD_ROSTER_PAGE_SIZE));
+  const page = clampPage(currentPage, totalPages);
+  const startIndex = (page - 1) * GUILD_ROSTER_PAGE_SIZE;
+  const visibleMembers = members.slice(startIndex, startIndex + GUILD_ROSTER_PAGE_SIZE);
+  const firstVisible = startIndex + 1;
+  const lastVisible = startIndex + visibleMembers.length;
+  const previousPage = page - 1;
+  const nextPage = page + 1;
 
-            return (
-              <tr
-                key={member.id}
-                className={getRevealClassName({
-                  className: "border-t border-gold-dim/70 hover:bg-bg-card/60 transition-colors",
-                })}
-                style={getRevealStyle(index)}
-              >
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-3">
-                    <PlayerAvatar
-                      name={member.characterName}
-                      realmName={member.realm}
-                      characterClass={member.className}
-                      raceName={member.raceName}
-                      guildName={member.guildName}
-                      color={classColor}
-                      fallbackIconUrl={getClassIconUrl(member.className)}
-                      size="xs"
-                    />
+  return (
+    <div className="overflow-hidden border border-gold-dim bg-bg-panel rounded">
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-bg-card text-text-dim">
+            <tr className="text-left text-[11px] uppercase tracking-widest">
+              <th className="px-4 py-3 font-semibold">Character</th>
+              <th className="px-4 py-3 font-semibold">Class</th>
+              <th className="px-4 py-3 font-semibold">Race</th>
+              <th className="px-4 py-3 font-semibold">Level</th>
+              <th className="px-4 py-3 font-semibold">Rank</th>
+              <th className="px-4 py-3 font-semibold">GS</th>
+              <th className="px-4 py-3 font-semibold">Professions</th>
+              <th className="px-4 py-3 font-semibold">Guild</th>
+              <th className="px-4 py-3 font-semibold">Realm</th>
+              <th className="px-4 py-3 font-semibold">Last Synced</th>
+              <th className="px-4 py-3 font-semibold text-right">Profile</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleMembers.map((member, index) => {
+              const classColor = getClassColor(member.className ?? member.characterName);
+
+              return (
+                <tr
+                  key={member.id}
+                  className={getRevealClassName({
+                    className: "border-t border-gold-dim/70 hover:bg-bg-card/60 transition-colors",
+                  })}
+                  style={getRevealStyle(index)}
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <PlayerAvatar
+                        name={member.characterName}
+                        realmName={member.realm}
+                        characterClass={member.className}
+                        raceName={member.raceName}
+                        guildName={member.guildName}
+                        color={classColor}
+                        fallbackIconUrl={getClassIconUrl(member.className)}
+                        size="xs"
+                      />
+                      <Link
+                        href={`/players/${encodeURIComponent(member.characterName)}`}
+                        className="font-semibold hover:text-gold-light transition-colors"
+                        style={{ color: classColor }}
+                      >
+                        {member.characterName}
+                      </Link>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary">{member.className ?? "Unknown"}</td>
+                  <td className="px-4 py-3 text-text-secondary">{member.raceName ?? "Unknown"}</td>
+                  <td className="px-4 py-3 text-text-secondary tabular-nums">{member.level ?? "-"}</td>
+                  <td className="px-4 py-3 text-text-secondary">{member.rankName ?? "-"}</td>
+                  <td className="px-4 py-3 text-text-secondary tabular-nums">
+                    {member.gearScore ? member.gearScore.toLocaleString() : "-"}
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary whitespace-nowrap">{formatProfessions(member.professionsJson)}</td>
+                  <td className="px-4 py-3 text-text-secondary">{member.guildName}</td>
+                  <td className="px-4 py-3 text-text-secondary">{member.realm}</td>
+                  <td className="px-4 py-3 text-text-dim whitespace-nowrap">{formatSyncedAt(member.lastSyncedAt)}</td>
+                  <td className="px-4 py-3 text-right">
                     <Link
                       href={`/players/${encodeURIComponent(member.characterName)}`}
-                      className="font-semibold hover:text-gold-light transition-colors"
-                      style={{ color: classColor }}
+                      className="text-xs font-semibold uppercase tracking-wide text-gold hover:text-gold-light"
                     >
-                      {member.characterName}
+                      View
                     </Link>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-text-secondary">{member.className ?? "Unknown"}</td>
-                <td className="px-4 py-3 text-text-secondary">{member.raceName ?? "Unknown"}</td>
-                <td className="px-4 py-3 text-text-secondary tabular-nums">{member.level ?? "-"}</td>
-                <td className="px-4 py-3 text-text-secondary">{member.rankName ?? "-"}</td>
-                <td className="px-4 py-3 text-text-secondary tabular-nums">
-                  {member.gearScore ? member.gearScore.toLocaleString() : "-"}
-                </td>
-                <td className="px-4 py-3 text-text-secondary whitespace-nowrap">{formatProfessions(member.professionsJson)}</td>
-                <td className="px-4 py-3 text-text-secondary">{member.guildName}</td>
-                <td className="px-4 py-3 text-text-secondary">{member.realm}</td>
-                <td className="px-4 py-3 text-text-dim whitespace-nowrap">{formatSyncedAt(member.lastSyncedAt)}</td>
-                <td className="px-4 py-3 text-right">
-                  <Link
-                    href={`/players/${encodeURIComponent(member.characterName)}`}
-                    className="text-xs font-semibold uppercase tracking-wide text-gold hover:text-gold-light"
-                  >
-                    View
-                  </Link>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t border-gold-dim bg-bg-card/60 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-text-dim tabular-nums">
+          {firstVisible}-{lastVisible} of {members.length} members
+        </p>
+        <nav className="flex items-center justify-end gap-2" aria-label="Guild roster pages">
+          <PageNavButton
+            href={getPageHref(previousPage)}
+            label="Previous roster page"
+            disabled={page <= 1}
+          >
+            <ChevronLeft aria-hidden="true" className="h-4 w-4" />
+            <span className="sr-only">Previous</span>
+          </PageNavButton>
+          <span className="min-w-20 text-center text-xs text-text-secondary tabular-nums">
+            Page {page} / {totalPages}
+          </span>
+          <PageNavButton
+            href={getPageHref(nextPage)}
+            label="Next roster page"
+            disabled={page >= totalPages}
+          >
+            <ChevronRight aria-hidden="true" className="h-4 w-4" />
+            <span className="sr-only">Next</span>
+          </PageNavButton>
+        </nav>
+      </div>
     </div>
   );
 }

--- a/tests/guild-roster-table-render.test.ts
+++ b/tests/guild-roster-table-render.test.ts
@@ -6,34 +6,35 @@ import { GuildRosterTable } from "../components/guild-roster/GuildRosterTable";
 const emptyMarkup = renderToStaticMarkup(React.createElement(GuildRosterTable, { members: [] }));
 assert.match(emptyMarkup, /No guild roster data yet/);
 
-const markup = renderToStaticMarkup(
-  React.createElement(GuildRosterTable, {
-    members: [
-      {
-        id: "1",
-        characterName: "Azyva",
-        normalizedCharacterName: "azyva",
-        guildName: "PizzaWarriors",
-        realm: "Lordaeron",
-        className: "Druid",
-        raceName: "Night Elf",
-        level: 80,
-        rankName: "Small Council",
-        rankOrder: 0,
-        professionsJson: [
-          { name: "Engineering", skill: 450 },
-          { name: "Jewelcrafting", skill: 450 },
-        ],
-        gearScore: 5875,
-        armoryUrl: "https://armory.warmane.com/character/Azyva/Lordaeron/summary",
-        gearSnapshotJson: null,
-        lastSyncedAt: new Date("2026-04-30T12:00:00.000Z"),
-        createdAt: new Date("2026-04-30T12:00:00.000Z"),
-        updatedAt: new Date("2026-04-30T12:00:00.000Z"),
-      },
+const members = Array.from({ length: 25 }, (_, index) => {
+  const number = index + 1;
+  const characterName = number === 1 ? "Azyva" : `Roster${number}`;
+
+  return {
+    id: String(number),
+    characterName,
+    normalizedCharacterName: characterName.toLowerCase(),
+    guildName: "PizzaWarriors",
+    realm: "Lordaeron",
+    className: "Druid",
+    raceName: "Night Elf",
+    level: 80,
+    rankName: "Small Council",
+    rankOrder: 0,
+    professionsJson: [
+      { name: "Engineering", skill: 450 },
+      { name: "Jewelcrafting", skill: 450 },
     ],
-  }),
-);
+    gearScore: 5875,
+    armoryUrl: `https://armory.warmane.com/character/${characterName}/Lordaeron/summary`,
+    gearSnapshotJson: null,
+    lastSyncedAt: new Date("2026-04-30T12:00:00.000Z"),
+    createdAt: new Date("2026-04-30T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-30T12:00:00.000Z"),
+  };
+});
+
+const markup = renderToStaticMarkup(React.createElement(GuildRosterTable, { members }));
 
 assert.match(markup, /Azyva/);
 assert.match(markup, /Druid/);
@@ -50,5 +51,20 @@ assert.match(markup, /data-character-race="Night Elf"/);
 assert.match(markup, /classicon_druid/);
 assert.match(markup, /reveal-item/);
 assert.match(markup, /--reveal-index:0/);
+assert.match(markup, /1-20 of 25 members/);
+assert.match(markup, /Page 1 \/ 2/);
+assert.match(markup, /href="\/guild-roster\?page=2"/);
+assert.match(markup, /Roster20/);
+assert.doesNotMatch(markup, /Roster21/);
+
+const secondPageMarkup = renderToStaticMarkup(
+  React.createElement(GuildRosterTable, { members, currentPage: 2 }),
+);
+
+assert.match(secondPageMarkup, /21-25 of 25 members/);
+assert.match(secondPageMarkup, /Page 2 \/ 2/);
+assert.match(secondPageMarkup, /href="\/guild-roster"/);
+assert.match(secondPageMarkup, /Roster21/);
+assert.doesNotMatch(secondPageMarkup, /Azyva/);
 
 console.log("guild-roster-table-render tests passed");


### PR DESCRIPTION
## Summary

- Limit the public guild roster table to 20 visible members per page.
- Add URL-backed `?page=` handling so roster pages can be linked or refreshed.
- Keep the roster rows inside the table panel and add previous/next navigation in the footer.
- Update vault handoff notes for the session.

## Validation

- Guild roster render test with JSX-aware `ts-node` registration passed.
- `node node_modules\typescript\bin\tsc --noEmit` passed.
- `node node_modules\eslint\bin\eslint.js . --max-warnings=0` passed.
- `npm run build` passed.
- Local `GET http://127.0.0.1:3001/guild-roster?page=2` returned HTTP 200 after the dev server compiled.

## Notes

Parser code was not changed.
