### PR TITLE
[codex] Refresh Pizza Logs README and wiki notes

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -19,6 +19,7 @@
 - GitHub CLI executable: `C:\Program Files\GitHub CLI\gh.exe`
 - Parser correctness remains the highest-risk area.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
+- README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
   - `C:\Projects\PizzaLogs\Start Pizza Logs Local.cmd`
   - `C:\Projects\PizzaLogs\Stop Pizza Logs Local.cmd`
@@ -91,6 +92,7 @@
 
 | Check | Result |
 |---|---|
+| README and wiki wording scan | Passed for updated public docs; no em dashes or AI-obvious wording patterns found |
 | Local README screenshot capture | Passed from fresh Next dev server on `http://127.0.0.1:3004`; parser service was listening on `127.0.0.1:8000` |
 | FFmpeg render script | Passed; all root and public animation variants generated |
 | Rendered frame inspection | Passed; watermark absent in desktop and mobile preview frames |

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -6,6 +6,8 @@ The current session added guild roster pagination so the public roster shows 20 
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
+Documentation metadata refresh: the README now links to the GitHub wiki, and the wiki has been rewritten with current upload, roster, gear, parser, roadmap, and branch workflow details.
+
 ## Current Branch Rule
 
 Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`. Codex does not push or merge `main` directly.
@@ -74,6 +76,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Roster table footer navigator | DONE | Previous/next icon links render in the table container footer |
 | Guild roster render coverage | DONE | Test covers page 1 and page 2 slicing |
 | README app preview | DONE | Added `docs/assets/readme-screenshot.png` and linked it from `README.md` |
+| README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 
 ## Open Follow-Ups
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Pizza Logs is a Warmane / WotLK 3.3.5a combat-log parser and leaderboard app for
 
 Live app: https://pizza-logs-production.up.railway.app
 
+Wiki: https://github.com/CRSD-Lau/Pizza-Logs/wiki
+
 ## App Preview
 
 ![Pizza Logs upload dashboard screenshot](docs/assets/readme-screenshot.png)


### PR DESCRIPTION
## Summary

- Links the README to the GitHub wiki.
- Updates the Pizza Logs handoff and focus notes for the public documentation refresh.
- Keeps the full wiki refresh in the separate GitHub wiki repository.

## Validation

- Ran `git diff --check` successfully for the Pizza Logs repo.
- Ran wording scans across the updated README and wiki pages for em dashes and obvious AI-style wording patterns.