### PR TITLE
Fix userscript admin secret targeting

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -2,7 +2,7 @@
 
 ## Date
 
-2026-05-08
+2026-05-09
 
 ## Branch
 
@@ -38,7 +38,23 @@
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
+- Gear userscript v1.7.1 and roster userscript v1.0.5 store admin secrets per Pizza Logs target origin and show their target in the Warmane panel, so local and production secrets no longer overwrite each other on `armory.warmane.com`.
 - The cinematic intro now uses generated video assets from `animations/source/Veo.mp4` instead of the retired `public/intro` asset set.
+
+## Tampermonkey Auth Session
+
+- Investigated `Pizza Logs Gear Sync` showing `Sync failed: Unauthorized.` on Warmane.
+- Root cause: the production and local Warmane userscripts both stored the admin secret under the same `armory.warmane.com` localStorage key, so switching between production and local scripts could reuse the wrong secret.
+- Updated gear and roster userscripts to use target-specific keys:
+  - `pizzaLogsAdminSecret:https://pizza-logs-production.up.railway.app`
+  - `pizzaLogsAdminSecret:http://127.0.0.1:3001`
+- Updated gear last-run storage to be target-specific as well.
+- Unauthorized responses now clear both the new target key and the old shared legacy key, then tell the admin which target rejected the secret.
+- Injected panels now show `Target: <host>` under the title.
+- Bumped userscript versions:
+  - Gear: `1.7.1`
+  - Roster: `1.0.5`
+- Local endpoints verified on `http://127.0.0.1:3001` after the local stack was started.
 
 ## Cinematic Intro Session
 
@@ -110,6 +126,15 @@
 | `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
 | `npm run build` | Passed |
 | Local `GET http://127.0.0.1:3001/guild-roster?page=2` | Passed with HTTP 200 after dev server compile |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\local-userscript-routes.test.ts` | Passed |
+| Gear/admin panel JSX-aware `ts-node` test | Passed |
+| Guild roster/admin panel JSX-aware `ts-node` test | Passed |
+| Local userscript endpoint version/key check | Passed for gear `1.7.1` and roster `1.0.5` |
+| `node node_modules\typescript\bin\tsc --noEmit` | Passed |
+| `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
+| `npm run build` | Passed |
 
 ## Remaining Risks
 
@@ -123,4 +148,4 @@
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR after the guild roster pagination commit is pushed. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR after the Tampermonkey auth fix is pushed. After deployment, reinstall/update the gear and roster userscripts from `/admin` so Tampermonkey receives gear `1.7.1` and roster `1.0.5`, then enter the admin secret that matches the shown target. Neil merges into `main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session added guild roster pagination so the public roster shows 20 members per page inside a contained table panel. Parser reliability remains the highest-risk product area, but no parser code changed in this session.
+The current session fixed Warmane Tampermonkey admin-secret confusion. Gear userscript `1.7.1` and roster userscript `1.0.5` now store secrets per Pizza Logs target origin and show the target host in the Warmane panel. Parser reliability remains the highest-risk product area, but no parser code changed in this session.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -14,6 +14,20 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Investigated the Warmane userscript status `Sync failed: Unauthorized.`
+- Confirmed this was a Pizza Logs admin-secret rejection, not a Warmane verification failure.
+- Fixed gear and roster userscripts so production and local installs no longer share the same `pizzaLogsAdminSecret` localStorage key on `armory.warmane.com`.
+- Added target-specific storage keys for production and local scripts.
+- Added target labels to the injected Warmane panels.
+- Changed unauthorized handling to clear the new target key plus the old legacy shared key and explain which target rejected the secret.
+- Bumped gear userscript to `1.7.1`.
+- Bumped roster userscript to `1.0.5`.
+- Verified local userscript endpoints on `http://127.0.0.1:3001` serve the new versions and target-specific keys.
+- Ran focused userscript tests; they passed.
+- Ran JSX-aware admin panel tests for gear and roster; they passed.
+- Ran `node node_modules\typescript\bin\tsc --noEmit`; it passed.
+- Ran `node node_modules\eslint\bin\eslint.js . --max-warnings=0`; it passed.
+- Ran `npm run build`; it passed.
 - Added URL-backed `?page=` handling on `/guild-roster`.
 - Updated `GuildRosterTable` to show 20 members per page.
 - Added a contained table panel footer with bottom-right previous/next page navigation.
@@ -77,6 +91,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Guild roster render coverage | DONE | Test covers page 1 and page 2 slicing |
 | README app preview | DONE | Added `docs/assets/readme-screenshot.png` and linked it from `README.md` |
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
+| Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
 
 ## Open Follow-Ups
 
@@ -85,6 +100,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.
+- After the userscript auth PR deploys, reinstall/update the production gear and roster userscripts from `/admin`; local `3001` variants are already serving the new scripts while the local server is running.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.
 - Link Railway with `railway link` only when intentionally working on Railway configuration; do not deploy without explicit instruction.

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -48,6 +48,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Local `rg` resolved to Codex app bundle and failed with Access denied | Installed standalone `ripgrep` with WinGet and prioritized its package directory in User PATH via `scripts/dev/setup-tooling.ps1` |
 | PR Slack message read like a raw dump | Reworked Slack blocks into a compact header, metadata fields, trimmed description, and cleaner changed-file list |
 | PR description headings showed unsupported Slack markdown | Added markdown normalization so GitHub headings become Slack bold labels |
+| Local and production Warmane userscripts shared the same saved admin secret | Gear `1.7.1` and roster `1.0.5` now use target-specific localStorage keys, show the target host, and clear the legacy shared key on unauthorized responses |
 
 ## Not Bugs
 

--- a/lib/armory-gear-client-scripts.ts
+++ b/lib/armory-gear-client-scripts.ts
@@ -317,10 +317,13 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
   const pizzaLogsOrigin = options.pizzaLogsOrigin ?? PIZZA_LOGS_ORIGIN;
   const userscriptUrl = options.userscriptUrl ?? USERSCRIPT_URL;
   const nameSuffix = options.nameSuffix ?? "";
+  const targetLabel = new URL(pizzaLogsOrigin).host;
   const script = function pizzaLogsWarmaneAutoSync() {
     const pizzaLogsOrigin = "__PIZZA_LOGS_ORIGIN__";
-    const secretKey = "pizzaLogsAdminSecret";
-    const lastRunKey = "pizzaLogsLastGearSyncAt";
+    const targetLabel = "__PIZZA_LOGS_TARGET__";
+    const legacySecretKey = "pizzaLogsAdminSecret";
+    const secretKey = "pizzaLogsAdminSecret:__PIZZA_LOGS_ORIGIN__";
+    const lastRunKey = "pizzaLogsLastGearSyncAt:__PIZZA_LOGS_ORIGIN__";
     const autoIntervalMs = 60 * 60 * 1000;
 
     console.info("Pizza Logs userscript starting", {
@@ -376,6 +379,10 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
       title.textContent = "Pizza Logs Gear Sync";
       title.style.cssText = "font-weight:700;color:#f1d36b;margin-bottom:6px";
 
+      const target = document.createElement("div");
+      target.textContent = `Target: ${targetLabel}`;
+      target.style.cssText = "font-size:11px;color:#8f836b;margin-bottom:8px";
+
       const status = document.createElement("div");
       status.textContent = "Ready";
       status.style.cssText = "line-height:1.35;color:#b8aa8c;margin-bottom:10px";
@@ -400,11 +407,12 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
       reset.style.cssText = "margin-top:8px;width:100%;border:0;background:transparent;color:#8f836b;cursor:pointer";
       reset.addEventListener("click", () => {
         localStorage.removeItem(secretKey);
+        localStorage.removeItem(legacySecretKey);
         localStorage.removeItem(lastRunKey);
         setStatus("Secret cleared. Click Sync now to enter it again.");
       });
 
-      panel.append(title, status, button, reset);
+      panel.append(title, target, status, button, reset);
       document.body.appendChild(panel);
       state.panel = panel;
       state.status = status;
@@ -585,8 +593,13 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
         setStatus(`Imported ${imported}; failed ${failed.length}${failed.length ? `. ${failed.slice(0, 3).join("; ")}` : "."}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        if (message === "Unauthorized.") localStorage.removeItem(secretKey);
-        setStatus(`Sync failed: ${message}`);
+        if (message === "Unauthorized.") {
+          localStorage.removeItem(secretKey);
+          localStorage.removeItem(legacySecretKey);
+          setStatus(`Admin secret rejected by ${targetLabel}. Click Sync now and enter the matching secret.`);
+        } else {
+          setStatus(`Sync failed: ${message}`);
+        }
       } finally {
         state.running = false;
         if (state.button) state.button.disabled = false;
@@ -610,7 +623,7 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Gear Auto Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.7.0",
+    "// @version      1.7.1",
     "// @description  Automatically sync Pizza Logs gear cache from Warmane Armory pages.",
     "// @match        https://armory.warmane.com/character/*",
     "// @match        http://armory.warmane.com/character/*",
@@ -620,6 +633,8 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
     "// @grant        GM_xmlhttpRequest",
     "// ==/UserScript==",
     "",
-    `(${script.toString().replace("__PIZZA_LOGS_ORIGIN__", pizzaLogsOrigin)})();`,
+    `(${script.toString()
+      .replaceAll("__PIZZA_LOGS_ORIGIN__", pizzaLogsOrigin)
+      .replaceAll("__PIZZA_LOGS_TARGET__", targetLabel)})();`,
   ].join("\n");
 }

--- a/lib/guild-roster-client-scripts.ts
+++ b/lib/guild-roster-client-scripts.ts
@@ -15,12 +15,15 @@ type GuildRosterUserscriptOptions = {
 };
 
 function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_ORIGIN): string {
+  const targetLabel = new URL(pizzaLogsOrigin).host;
   const script = function pizzaLogsRosterSync() {
     const pizzaLogsOrigin = "__PIZZA_LOGS_ORIGIN__";
+    const targetLabel = "__PIZZA_LOGS_TARGET__";
     const guildName = "__DISPLAY_GUILD_NAME__";
     const warmaneGuildName = "__WARMANE_GUILD_NAME__";
     const realm = "__WARMANE_REALM__";
-    const secretKey = "pizzaLogsAdminSecret";
+    const legacySecretKey = "pizzaLogsAdminSecret";
+    const secretKey = "pizzaLogsAdminSecret:__PIZZA_LOGS_ORIGIN__";
 
     if (location.hostname !== "armory.warmane.com") {
       alert("Pizza Logs: open Warmane Armory first, then run the roster importer.");
@@ -114,8 +117,13 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
         setStatus(`Imported ${result.count} roster ${result.count === 1 ? "member" : "members"}.`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        if (message === "Unauthorized.") localStorage.removeItem(secretKey);
-        setStatus(`Roster sync failed: ${message}`);
+        if (message === "Unauthorized.") {
+          localStorage.removeItem(secretKey);
+          localStorage.removeItem(legacySecretKey);
+          setStatus(`Admin secret rejected by ${targetLabel}. Click Sync roster and enter the matching secret.`);
+        } else {
+          setStatus(`Roster sync failed: ${message}`);
+        }
       } finally {
         state.running = false;
         if (state.button) state.button.disabled = false;
@@ -149,6 +157,10 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
       title.textContent = "Pizza Logs Roster Sync";
       title.style.cssText = "font-weight:700;color:#f1d36b;margin-bottom:6px";
 
+      const target = document.createElement("div");
+      target.textContent = `Target: ${targetLabel}`;
+      target.style.cssText = "font-size:11px;color:#8f836b;margin-bottom:8px";
+
       const status = document.createElement("div");
       status.textContent = "Open the Pizza Warriors guild page, then click Sync roster.";
       status.style.cssText = "line-height:1.35;color:#b8aa8c;margin-bottom:10px";
@@ -173,10 +185,11 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
       reset.style.cssText = "margin-top:8px;width:100%;border:0;background:transparent;color:#8f836b;cursor:pointer";
       reset.addEventListener("click", () => {
         localStorage.removeItem(secretKey);
+        localStorage.removeItem(legacySecretKey);
         setStatus("Secret cleared. Click Sync roster to enter it again.");
       });
 
-      panel.append(title, status, button, reset);
+      panel.append(title, target, status, button, reset);
       document.body.appendChild(panel);
       state.panel = panel;
       state.status = status;
@@ -192,7 +205,8 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
   };
 
   return `(${script.toString()
-    .replace("__PIZZA_LOGS_ORIGIN__", pizzaLogsOrigin)
+    .replaceAll("__PIZZA_LOGS_ORIGIN__", pizzaLogsOrigin)
+    .replaceAll("__PIZZA_LOGS_TARGET__", targetLabel)
     .replaceAll("__DISPLAY_GUILD_NAME__", DISPLAY_GUILD_NAME)
     .replaceAll("__WARMANE_GUILD_NAME__", WARMANE_GUILD_NAME)
     .replaceAll("__WARMANE_REALM__", WARMANE_REALM)
@@ -215,7 +229,7 @@ export function buildGuildRosterUserscript(options: GuildRosterUserscriptOptions
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Guild Roster Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.0.4",
+    "// @version      1.0.5",
     "// @description  Sync Pizza Logs guild roster from Warmane Armory in-browser.",
     "// @match        https://armory.warmane.com/guild/*",
     "// @match        http://armory.warmane.com/guild/*",

--- a/tests/armory-gear-client-scripts.test.ts
+++ b/tests/armory-gear-client-scripts.test.ts
@@ -34,9 +34,15 @@ assert.match(localUserscript, new RegExp(`// @downloadURL\\s+${LOCAL_USERSCRIPT_
 assert.match(localUserscript, new RegExp(`// @updateURL\\s+${LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 assert.match(localUserscript, new RegExp(`const pizzaLogsOrigin = "${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}";`));
 assert.match(localUserscript, /\/api\/admin\/armory-gear\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.7\.0/);
+assert.match(userscript, /\/\/ @version\s+1\.7\.1/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/character\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/character\/\*/);
+assert.match(userscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+assert.match(localUserscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+assert.doesNotMatch(localUserscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+assert.match(localUserscript, /const targetLabel = "127\.0\.0\.1:3001"/);
+assert.match(localUserscript, /target\.textContent = `Target: \$\{targetLabel\}`/);
+assert.match(localUserscript, /Admin secret rejected by \$\{targetLabel\}/);
 assert.match(userscript, /isCharacterPage/);
 assert.match(userscript, /mergePageIconsIntoWarmaneData/);
 assert.match(userscript, /readPageItemIcons/);
@@ -60,8 +66,8 @@ async function verifyUserscriptMergesDomIconFallback() {
   const pending: Promise<unknown>[] = [];
   const importBodies: Array<{ equipment?: Array<{ item?: string; iconUrl?: string }> }> = [];
   const storage = new Map<string, string>([
-    ["pizzaLogsAdminSecret", "secret"],
-    ["pizzaLogsLastGearSyncAt", "0"],
+    [`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN}`, "secret"],
+    [`pizzaLogsLastGearSyncAt:${PIZZA_LOGS_ORIGIN}`, "0"],
   ]);
 
   const context = {
@@ -137,8 +143,8 @@ async function verifyUserscriptFetchesQueuedPlayerPageIcons() {
   const pending: Promise<unknown>[] = [];
   const importBodies: Array<{ equipment?: Array<{ item?: string; iconUrl?: string }> }> = [];
   const storage = new Map<string, string>([
-    ["pizzaLogsAdminSecret", "secret"],
-    ["pizzaLogsLastGearSyncAt", "0"],
+    [`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN}`, "secret"],
+    [`pizzaLogsLastGearSyncAt:${PIZZA_LOGS_ORIGIN}`, "0"],
   ]);
 
   const makeIconDocument = () => ({

--- a/tests/guild-roster-client-scripts.test.ts
+++ b/tests/guild-roster-client-scripts.test.ts
@@ -15,9 +15,10 @@ const localUserscript = buildGuildRosterUserscript({
 });
 assert.match(userscript, /Pizza Logs Warmane Guild Roster Sync/);
 assert.match(userscript, /api\/admin\/guild-roster\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.0\.4/);
+assert.match(userscript, /\/\/ @version\s+1\.0\.5/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/guild\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/guild\/\*/);
+assert.match(userscript, /pizzaLogsAdminSecret:https:\/\/pizza-logs-production\.up\.railway\.app/);
 assert.match(userscript, /isGuildPage/);
 assert.match(userscript, /api\/guild\/Pizza\+Warriors\/Lordaeron\/summary/);
 assert.match(userscript, /guild\/Pizza\+Warriors\/Lordaeron\/summary/);
@@ -29,6 +30,11 @@ assert.match(userscript, new RegExp(GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^$
 assert.match(localUserscript, /Pizza Logs Warmane Guild Roster Sync \(Local\)/);
 assert.match(localUserscript, new RegExp(LOCAL_GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 assert.match(localUserscript, new RegExp(`const pizzaLogsOrigin = "${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}";`));
+assert.match(localUserscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+assert.doesNotMatch(localUserscript, /pizzaLogsAdminSecret:https:\/\/pizza-logs-production\.up\.railway\.app/);
+assert.match(localUserscript, /const targetLabel = "127\.0\.0\.1:3001"/);
+assert.match(localUserscript, /target\.textContent = `Target: \$\{targetLabel\}`/);
+assert.match(localUserscript, /Admin secret rejected by \$\{targetLabel\}/);
 assert.match(localUserscript, /\/api\/admin\/guild-roster\/import/);
 
 const bookmarklet = buildGuildRosterBookmarklet();


### PR DESCRIPTION
## Summary
- Separate Warmane userscript admin-secret storage by Pizza Logs target origin so local and production installs do not reuse the same secret on armory.warmane.com.
- Show the target host in the gear and roster userscript panels, clear the legacy shared key on unauthorized responses, and bump userscript versions.
- Update vault handoff/current/known-issues notes.

## Validation
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\local-userscript-routes.test.ts
- JSX-aware ts-node gear/admin panel test
- JSX-aware ts-node guild roster/admin panel test
- node node_modules\typescript\bin\tsc --noEmit
- node node_modules\eslint\bin\eslint.js . --max-warnings=0
- npm run build

@codex review please focus on admin userscript auth behavior, local/prod target separation, accidental secret exposure, and Railway deployment risk.