### PR TITLE
[codex] Fix ICC heroic difficulty markers

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -2,7 +2,7 @@
 
 ## Date
 
-2026-05-09
+2026-05-10
 
 ## Branch
 
@@ -18,6 +18,9 @@
 - Local Git executable fallback: `C:\Program Files\Git\cmd\git.exe`
 - GitHub CLI executable: `C:\Program Files\GitHub CLI\gh.exe`
 - Parser correctness remains the highest-risk area.
+- ICC heroic difficulty detection now uses boss-scoped markers. `Rune of Blood`
+  no longer promotes Deathbringer Saurfang; Saurfang heroic uses `Scent of Blood`
+  spell IDs, and Valithria heroic uses `Twisted Nightmares`.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -34,6 +37,10 @@
 - `/admin`, `/admin/uploads`, cleanup actions, and admin import APIs are protected by `ADMIN_SECRET`.
 - Upload flow streams multipart data from `app/api/upload/route.ts` to parser `/parse-stream`, then writes database rows and milestones.
 - Parser supports both encounter marker and heuristic segmentation paths, with Skada-aligned damage/healing formulas documented in `docs/parser-contract.md`.
+- Parser heroic upgrade markers are boss-scoped to reduce mixed-raid false positives:
+  Saurfang `Rune of Blood` is normal-capable, Saurfang `Scent of Blood`
+  IDs `72769`/`72771` are heroic evidence, and Valithria `Twisted Nightmares`
+  IDs `71940`/`71941` or name are heroic evidence.
 - Gear pages read cached Warmane snapshots, enrich from local AzerothCore `wow_items`, and attempt Warmane live fetches only as best effort.
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
@@ -78,6 +85,22 @@
 - Intro brand text is larger and positioned about 15% down from the top while remaining horizontally centered.
 - Removed obsolete `public/intro/` generated assets.
 - Updated README, `docs/intro-animation.md`, `AGENTS.md`, `.gitignore`, source tests, and vault notes.
+
+## ICC Difficulty Marker Session
+
+- Investigated latest mixed ICC raid labels where Deathbringer Saurfang was shown
+  heroic despite being normal, and Valithria Dreamwalker was shown normal despite
+  being heroic.
+- Root cause: `Rune of Blood` was treated as a Saurfang heroic-only marker, but it
+  appears in normal Saurfang. Valithria had no `Twisted Nightmares` heroic marker.
+- Replaced the global heroic marker set with boss-scoped marker matching.
+- Removed Saurfang `Rune of Blood` from heroic evidence.
+- Added Saurfang heroic `Scent of Blood` spell ID markers `72769` and `72771`.
+- Added Valithria heroic `Twisted Nightmares` spell ID markers `71940` and `71941`,
+  plus name matching.
+- Added focused parser regression tests for Saurfang `Rune of Blood`, Saurfang
+  `Scent of Blood`, and Valithria `Twisted Nightmares`.
+- Updated `docs/parser-contract.md` and known-issues notes.
 
 ## Guild Roster Pagination Session
 
@@ -135,6 +158,9 @@
 | `node node_modules\typescript\bin\tsc --noEmit` | Passed |
 | `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
 | `npm run build` | Passed |
+| `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares" -v` | Failed before fix with the expected three difficulty assertions |
+| `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares or heroic_detected_with_encounter_start" -v` | Passed |
+| `python -m pytest tests/ -v` from `parser/` | Passed: 136 passed, 1 existing Pydantic deprecation warning |
 
 ## Remaining Risks
 
@@ -148,4 +174,8 @@
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR after the Tampermonkey auth fix is pushed. After deployment, reinstall/update the gear and roster userscripts from `/admin` so Tampermonkey receives gear `1.7.1` and roster `1.0.5`, then enter the admin secret that matches the shown target. Neil merges into `main` only after review; Codex does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR for the ICC difficulty marker fix. After
+deployment, reprocess or re-upload the affected latest raid so the stored
+Deathbringer Saurfang and Valithria Dreamwalker rows are regenerated with the
+correct difficulties. Neil merges into `main` only after review; Codex does not
+merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session fixed Warmane Tampermonkey admin-secret confusion. Gear userscript `1.7.1` and roster userscript `1.0.5` now store secrets per Pizza Logs target origin and show the target host in the Warmane panel. Parser reliability remains the highest-risk product area, but no parser code changed in this session.
+The current session fixed latest mixed-ICC difficulty drift. Deathbringer Saurfang no longer upgrades to heroic from normal-mode `Rune of Blood`, and Valithria Dreamwalker now upgrades to heroic from `Twisted Nightmares` evidence. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -14,6 +14,17 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Investigated the latest raid report where Deathbringer Saurfang was normal but displayed heroic, and Valithria Dreamwalker was heroic but displayed normal.
+- Confirmed the parser treated `Rune of Blood` as heroic evidence even though it appears in normal Saurfang.
+- Confirmed Valithria had no heroic marker for `Twisted Nightmares`.
+- Added failing parser tests for Saurfang `Rune of Blood`, Saurfang `Scent of Blood`, and Valithria `Twisted Nightmares`.
+- Replaced global heroic marker matching with boss-scoped marker matching.
+- Removed Saurfang `Rune of Blood` from heroic evidence.
+- Added Saurfang heroic `Scent of Blood` spell IDs `72769` and `72771`.
+- Added Valithria heroic `Twisted Nightmares` spell IDs `71940` and `71941`, plus name matching.
+- Updated `docs/parser-contract.md`, `Latest Handoff.md`, and `Known Issues.md`.
+- Ran focused parser difficulty tests; they failed before the fix and passed after the fix.
+- Ran `python -m pytest tests/ -v` from `parser/`; it passed with 136 tests and 1 existing Pydantic deprecation warning.
 - Investigated the Warmane userscript status `Sync failed: Unauthorized.`
 - Confirmed this was a Pizza Logs admin-secret rejection, not a Warmane verification failure.
 - Fixed gear and roster userscripts so production and local installs no longer share the same `pizzaLogsAdminSecret` localStorage key on `armory.warmane.com`.
@@ -92,6 +103,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | README app preview | DONE | Added `docs/assets/readme-screenshot.png` and linked it from `README.md` |
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
+| ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
 
 ## Open Follow-Ups
 
@@ -101,6 +113,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.
 - After the userscript auth PR deploys, reinstall/update the production gear and roster userscripts from `/admin`; local `3001` variants are already serving the new scripts while the local server is running.
+- After this parser fix deploys, reprocess or re-upload the affected latest raid so stored Saurfang and Valithria difficulties are regenerated.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.
 - Link Railway with `railway link` only when intentionally working on Railway configuration; do not deploy without explicit instruction.

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -42,6 +42,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Parser `/parse-stream` accepted unsupported filenames | Added `.txt`/`.log` filename validation before temp-file handling |
 | Short explicit marker pulls could be discarded | Marker-based encounters now bypass the heuristic minimum-event floor |
 | Heroic wipes could promote later normal kills | Non-Gunship `25N` pulls no longer inherit heroic solely from same-session evidence |
+| Saurfang/Valithria heroic labels drifted on mixed ICC raids | Removed normal-mode `Rune of Blood` as a Saurfang heroic marker, added ID-based Saurfang `Scent of Blood`, and added Valithria `Twisted Nightmares` heroic detection |
 | Cinematic intro overlay existed but stayed invisible | Replaced dynamically composed Tailwind phase class with static class strings so `frozen-intro-overlay--showing` is emitted |
 | Cinematic intro audio was missing | Render scripts preserve audio tracks, and the intro overlay now has a sound toggle while still starting muted for autoplay |
 | Missing PR Slack webhook failed PR checks | Workflow now warns and exits successfully when `PR_SLACK_WEBHOOK_URL` is absent |

--- a/docs/parser-contract.md
+++ b/docs/parser-contract.md
@@ -99,17 +99,19 @@ Warmane may emit difficultyID=4 (25N) for heroic runs. Proceed to Step 2.
 
 ### Step 2: Heroic spell markers (applied even when ENCOUNTER_START present)
 
-If any of the following spell names appear in the segment AND difficulty is currently
-`10N` or `25N`, upgrade to `10H` or `25H`:
+If any of the following boss-specific spell names or spell IDs appear in the
+segment AND difficulty is currently `10N` or `25N`, upgrade to `10H` or `25H`:
 
-| Spell | Boss | Source |
+| Marker | Boss | Source |
 |---|---|---|
 | Bone Slice | Lord Marrowgar (ICC) | Skada — heroic-only multi-target cleave |
-| Rune of Blood | Deathbringer Saurfang (ICC) | Skada — heroic-only debuff |
+| Scent of Blood spell IDs 72769 / 72771 | Deathbringer Saurfang (ICC) | Heroic-only Blood Beast mechanic; ID-based to avoid Death Knight spell-name collisions |
+| Twisted Nightmares spell IDs 71940 / 71941 or name | Valithria Dreamwalker (ICC) | Heroic replacement for Emerald Vigor |
 | Pact of the Darkfallen | Blood-Queen Lana'thel (ICC) | Skada — heroic-only group link |
 | Unbound Plague | Professor Putricide (ICC) | Skada — heroic-only spreading debuff |
 
 **Excluded markers** (appear in 10N on Warmane, cannot be used as heroic indicators):
+- Rune of Blood (Deathbringer Saurfang)
 - Backlash (Sindragosa)
 - Empowered Shock Vortex / Empowered Shadow Lance / Empowered Blood (Blood Prince Council)
 

--- a/parser/parser_core.py
+++ b/parser/parser_core.py
@@ -28,24 +28,34 @@ from combat_metrics import (
 
 # ── Constants ─────────────────────────────────────────────────────
 
-# Spell names that only appear in heroic difficulty encounters.
+# Spell names that only appear in heroic difficulty encounters, keyed by boss.
 # Used to upgrade "25N"/"10N" to "25H"/"10H" — runs regardless of whether
 # ENCOUNTER_START is present, because Warmane emits difficultyID=4 (25N) for heroic runs.
-HEROIC_SPELL_MARKERS: frozenset[str] = frozenset({
+HEROIC_SPELL_NAME_MARKERS_BY_BOSS: dict[str, frozenset[str]] = {
     # Lord Marrowgar (ICC) — multi-target cleave only present in heroic
-    "bone slice",
-    # Deathbringer Saurfang (ICC) — heroic debuff DoT
-    "rune of blood",
+    "lord marrowgar": frozenset({"bone slice"}),
+    # Valithria Dreamwalker (ICC) — heroic replacement for Emerald Vigor
+    "valithria dreamwalker": frozenset({"twisted nightmares"}),
     # Blood-Queen Lana'thel (ICC) — heroic group link mechanic
-    "pact of the darkfallen",
+    "blood-queen lana'thel": frozenset({"pact of the darkfallen"}),
     # Professor Putricide (ICC) — spreads between players in heroic only
-    "unbound plague",
+    "professor putricide": frozenset({"unbound plague"}),
     # NOTE: "backlash" (Sindragosa) and "empowered shock vortex" / "empowered shadow lance" /
     # "empowered blood" (Blood Prince Council) are intentionally EXCLUDED here.
     # On Warmane these spells also appear in 10N, so they cannot be used as heroic-exclusive
     # markers.  Sindragosa and BPC without direct heroic evidence stay normal rather
     # than inheriting heroic state from another pull in the same session.
-})
+}
+
+# Spell IDs for heroic markers where name-only matching is unsafe. Death Knights
+# also have a "Scent of Blood" talent/proc, so Saurfang detection uses boss spell
+# IDs instead of the shared spell name.
+HEROIC_SPELL_ID_MARKERS_BY_BOSS: dict[str, frozenset[int]] = {
+    # Deathbringer Saurfang (ICC) — heroic Blood Beast raid slow/damage buff
+    "deathbringer saurfang": frozenset({72769, 72771}),
+    # Valithria Dreamwalker (ICC) — aura plus triggered periodic damage
+    "valithria dreamwalker": frozenset({71940, 71941}),
+}
 
 # Gunship Battle: Warmane emits ENCOUNTER_END success=0 even on a genuine kill
 # (the fight ends via scripted ship destruction, not a boss UNIT_DIED).
@@ -731,20 +741,13 @@ class CombatLogParser:
 
         # Heroic upgrade: run even when ENCOUNTER_START was present, because Warmane
         # (and many WotLK private servers) emit difficultyID=4 (25N) for heroic runs.
-        # HEROIC_SPELL_MARKERS contains spells that only appear in heroic difficulty.
+        # Heroic marker constants contain spells that only appear in heroic difficulty.
         # If the difficulty was correctly set to H via difficultyID, the replace() is a no-op.
-        if difficulty in ("10N", "25N") and self._detect_heroic(segment):
+        heroic_markers_found = self._find_heroic_markers(segment, boss_name)
+        if difficulty in ("10N", "25N") and heroic_markers_found:
             difficulty = difficulty.replace("N", "H")
             if debug and difficulty != _debug_difficulty_raw:
-                for _, _mp, _ in segment:
-                    if _mp[0] == "SWING_DAMAGE" or _mp[0] == UNIT_DIED_EVENT:
-                        continue
-                    if len(_mp) > 8:
-                        spell = _mp[8].strip('"').strip().lower()
-                        if spell in HEROIC_SPELL_MARKERS:
-                            marker = _mp[8].strip('"').strip()
-                            if marker not in _debug_markers:
-                                _debug_markers.append(marker)
+                _debug_markers = heroic_markers_found
 
         if not boss_name:
             if debug:
@@ -1106,16 +1109,38 @@ class CombatLogParser:
             return 10, "10N"
         return 25, "25N"
 
-    def _detect_heroic(self, segment: list[tuple[str, list[str], float]]) -> bool:
-        """Return True if any heroic-only spell marker appears in the segment."""
+    def _find_heroic_markers(
+        self,
+        segment: list[tuple[str, list[str], float]],
+        boss_name: Optional[str],
+    ) -> list[str]:
+        """Return heroic-only marker names found in a boss-specific segment."""
+        if not boss_name:
+            return []
+        boss_key = boss_name.lower()
+        name_markers: set[str] = set()
+        id_markers: set[int] = set()
+        for marker_boss, markers in HEROIC_SPELL_NAME_MARKERS_BY_BOSS.items():
+            if marker_boss in boss_key:
+                name_markers.update(markers)
+        for marker_boss, markers in HEROIC_SPELL_ID_MARKERS_BY_BOSS.items():
+            if marker_boss in boss_key:
+                id_markers.update(markers)
+        if not name_markers and not id_markers:
+            return []
+
+        found: list[str] = []
         for _, parts, _ in segment:
             if parts[0] == "SWING_DAMAGE" or parts[0] == UNIT_DIED_EVENT:
                 continue
             if len(parts) > 8:
+                spell_id = _safe_int(parts[7])
                 spell = parts[8].strip('"').strip().lower()
-                if spell in HEROIC_SPELL_MARKERS:
-                    return True
-        return False
+                if spell in name_markers or spell_id in id_markers:
+                    marker = parts[8].strip('"').strip()
+                    if marker and marker not in found:
+                        found.append(marker)
+        return found
 
     def _infer_outcome(
         self, segment: list[tuple[str, list[str], float]], boss_name: Optional[str]

--- a/parser/tests/test_parser_core.py
+++ b/parser/tests/test_parser_core.py
@@ -47,13 +47,14 @@ def _spell_damage_parts(src_guid: str, src_name: str,
                         dst_guid: str, dst_name: str,
                         amount: int, spell: str = "Fireball",
                         event: str = "SPELL_DAMAGE",
+                        spell_id: int = 133,
                         overkill: int = 0) -> list[str]:
     """Build a minimal SPELL_DAMAGE parts list (18 fields)."""
     return [
         event,
         src_guid, f'"{src_name}"', "0x512",
         dst_guid, f'"{dst_name}"', "0xa48",
-        "133", f'"{spell}"', "4",
+        str(spell_id), f'"{spell}"', "4",
         str(amount), str(overkill), "4", "0", "0", "0", "0", "0",
     ]
 
@@ -2001,6 +2002,8 @@ def _make_encounter_start_segment(
     diff_id: int,
     group_size: int,
     heroic_spell: str | None = None,
+    heroic_spell_id: int = 133,
+    heroic_event: str = "SPELL_DAMAGE",
     extra_player_count: int = 0,
 ) -> list[tuple[str, list[str], float]]:
     """Build a minimal segment with ENCOUNTER_START/END and optional heroic spell."""
@@ -2019,6 +2022,8 @@ def _make_encounter_start_segment(
                 PLAYER_GUID, "Phyre",
                 NPC_GUID, boss_name,
                 50_000, spell=heroic_spell,
+                spell_id=heroic_spell_id,
+                event=heroic_event,
             ),
             ts_base + 1,
         ))
@@ -2047,6 +2052,45 @@ def test_heroic_detected_with_encounter_start_25h():
     seg = _make_encounter_start_segment(
         "Lord Marrowgar", diff_id=4, group_size=25,
         heroic_spell="Bone Slice", extra_player_count=20,
+    )
+    p = CombatLogParser()
+    enc = p._aggregate_segment(seg, {})
+    assert enc is not None
+    assert enc.difficulty == "25H", f"Expected 25H, got {enc.difficulty}"
+
+
+def test_saurfang_rune_of_blood_does_not_upgrade_to_heroic():
+    """Rune of Blood exists on normal Saurfang and must not be a heroic marker."""
+    seg = _make_encounter_start_segment(
+        "Deathbringer Saurfang", diff_id=4, group_size=25,
+        heroic_spell="Rune of Blood", heroic_spell_id=72410,
+        heroic_event="SPELL_AURA_APPLIED", extra_player_count=20,
+    )
+    p = CombatLogParser()
+    enc = p._aggregate_segment(seg, {})
+    assert enc is not None
+    assert enc.difficulty == "25N", f"Expected 25N, got {enc.difficulty}"
+
+
+def test_saurfang_scent_of_blood_spell_id_upgrades_to_heroic():
+    """Saurfang heroic logs Scent of Blood as the safe direct heroic marker."""
+    seg = _make_encounter_start_segment(
+        "Deathbringer Saurfang", diff_id=4, group_size=25,
+        heroic_spell="Scent of Blood", heroic_spell_id=72769,
+        heroic_event="SPELL_AURA_APPLIED", extra_player_count=20,
+    )
+    p = CombatLogParser()
+    enc = p._aggregate_segment(seg, {})
+    assert enc is not None
+    assert enc.difficulty == "25H", f"Expected 25H, got {enc.difficulty}"
+
+
+def test_valithria_twisted_nightmares_upgrades_to_heroic():
+    """Heroic Valithria replaces Emerald Vigor with Twisted Nightmares."""
+    seg = _make_encounter_start_segment(
+        "Valithria Dreamwalker", diff_id=4, group_size=25,
+        heroic_spell="Twisted Nightmares", heroic_spell_id=71941,
+        heroic_event="SPELL_AURA_APPLIED", extra_player_count=20,
     )
     p = CombatLogParser()
     enc = p._aggregate_segment(seg, {})


### PR DESCRIPTION
## Summary

Fixes ICC heroic difficulty detection for mixed raid nights and cleans up the session player comparison graph:

- removes `Rune of Blood` as Deathbringer Saurfang heroic evidence because it appears on normal mode
- adds boss-scoped heroic marker matching instead of one global spell-name set
- adds Saurfang `Scent of Blood` spell ID markers `72769` / `72771`
- adds Valithria `Twisted Nightmares` spell ID markers `71940` / `71941` plus name matching
- filters the session player DPS/HPS by encounter chart to kills only, while keeping wipes in Encounter Breakdown
- updates parser contract and vault handoff/known-issues notes

## Root Cause

The parser treated `Rune of Blood` as a heroic-only Saurfang marker, causing normal DBS pulls to be saved as heroic. Valithria had no heroic marker for `Twisted Nightmares`, so Warmane `difficultyID=4` heroic Valithria pulls stayed normal.

The player session chart also built its line-series data from every pull in the session, so wipe attempts cluttered the DPS/HPS trend even though averages and leaderboards are kill-focused.

## Validation

- Red parser test run first: `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares" -v` failed with the expected three difficulty assertions
- Focused parser green run: `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares or heroic_detected_with_encounter_start" -v`
- Full parser suite: `python -m pytest tests/ -v` from `parser/` passed, 136 passed with 1 existing Pydantic deprecation warning
- Chart regression: `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\session-player-chart.test.ts`
- TypeScript: `node node_modules\typescript\bin\tsc --noEmit`
- ESLint: `node node_modules\eslint\bin\eslint.js . --max-warnings=0`
- Build: `npm run build`
- `git diff --check` passed
- Local rendered route with fixture data returned HTTP 200; in-app browser page identity and console checks passed, but browser screenshot capture timed out

## Deployment Note

After this parser fix deploys, the affected latest raid needs to be reprocessed or re-uploaded so the stored Saurfang and Valithria encounter rows are regenerated.

@codex review: please focus on parser correctness, Skada/Warmane heroic marker alignment, mixed heroic/normal ICC sessions, session player chart filtering, fixture/test coverage, and accidental secret exposure.