### PR TITLE
[codex] Exclude wipes from session player charts

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -21,6 +21,8 @@
 - ICC heroic difficulty detection now uses boss-scoped markers. `Rune of Blood`
   no longer promotes Deathbringer Saurfang; Saurfang heroic uses `Scent of Blood`
   spell IDs, and Valithria heroic uses `Twisted Nightmares`.
+- Session player comparison charts now graph kills only, so wipe pulls no longer
+  clutter the DPS/HPS by encounter trend.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -41,6 +43,8 @@
   Saurfang `Rune of Blood` is normal-capable, Saurfang `Scent of Blood`
   IDs `72769`/`72771` are heroic evidence, and Valithria `Twisted Nightmares`
   IDs `71940`/`71941` or name are heroic evidence.
+- `/raids/[id]/sessions/[sessionIdx]/players/[playerName]` still lists all pulls
+  in Encounter Breakdown, but its line chart now builds from kill encounters only.
 - Gear pages read cached Warmane snapshots, enrich from local AzerothCore `wow_items`, and attempt Warmane live fetches only as best effort.
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
@@ -102,6 +106,15 @@
   `Scent of Blood`, and Valithria `Twisted Nightmares`.
 - Updated `docs/parser-contract.md` and known-issues notes.
 
+## Session Player Chart Session
+
+- Updated the session player comparison line chart to exclude wipe pulls.
+- Added `lib/session-player-chart.ts` as the chart-data builder so kill-only
+  filtering is covered outside the page component.
+- Added `tests/session-player-chart.test.ts` proving wipe-only bosses do not
+  appear in chart data and missing classmates remain `null` on kill pulls.
+- The Encounter Breakdown list remains unchanged and still shows wipes.
+
 ## Guild Roster Pagination Session
 
 - Updated the public guild roster page to read `?page=` and pass the current page into the roster table.
@@ -161,6 +174,12 @@
 | `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares" -v` | Failed before fix with the expected three difficulty assertions |
 | `python -m pytest tests/test_parser_core.py -k "saurfang_rune_of_blood or saurfang_scent_of_blood or valithria_twisted_nightmares or heroic_detected_with_encounter_start" -v` | Passed |
 | `python -m pytest tests/ -v` from `parser/` | Passed: 136 passed, 1 existing Pydantic deprecation warning |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\session-player-chart.test.ts` | Failed before helper existed, then passed after implementation |
+| `node node_modules\typescript\bin\tsc --noEmit` | Passed |
+| `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
+| `npm run build` | Passed |
+| Local `GET http://127.0.0.1:3001/raids/chart-fixture-upload/sessions/0/players/Lausudo` | Passed with HTTP 200 against a local-only chart fixture |
+| In-app browser route load for local chart fixture | Passed page identity and console checks; screenshot capture timed out in the browser runtime |
 
 ## Remaining Risks
 
@@ -174,8 +193,8 @@
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR for the ICC difficulty marker fix. After
-deployment, reprocess or re-upload the affected latest raid so the stored
-Deathbringer Saurfang and Valithria Dreamwalker rows are regenerated with the
-correct difficulties. Neil merges into `main` only after review; Codex does not
-merge or push `main` directly.
+Review the `codex-dev` to `main` PR for the ICC difficulty marker fix and the
+session player chart kill-only update. After deployment, reprocess or re-upload
+the affected latest raid so the stored Deathbringer Saurfang and Valithria
+Dreamwalker rows are regenerated with the correct difficulties. Neil merges into
+`main` only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session fixed latest mixed-ICC difficulty drift. Deathbringer Saurfang no longer upgrades to heroic from normal-mode `Rune of Blood`, and Valithria Dreamwalker now upgrades to heroic from `Twisted Nightmares` evidence. Parser reliability remains the highest-risk product area.
+The current session fixed latest mixed-ICC difficulty drift and removed wipe pulls from the session player DPS/HPS by encounter chart. Deathbringer Saurfang no longer upgrades to heroic from normal-mode `Rune of Blood`, and Valithria Dreamwalker now upgrades to heroic from `Twisted Nightmares` evidence. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -25,6 +25,14 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Updated `docs/parser-contract.md`, `Latest Handoff.md`, and `Known Issues.md`.
 - Ran focused parser difficulty tests; they failed before the fix and passed after the fix.
 - Ran `python -m pytest tests/ -v` from `parser/`; it passed with 136 tests and 1 existing Pydantic deprecation warning.
+- Updated the session player comparison chart to build from kill encounters only.
+- Added `lib/session-player-chart.ts` and `tests/session-player-chart.test.ts`.
+- Confirmed the chart-data test failed before the helper existed and passed after implementation.
+- Ran `node node_modules\typescript\bin\tsc --noEmit`; it passed.
+- Ran `node node_modules\eslint\bin\eslint.js . --max-warnings=0`; it passed.
+- Ran `npm run build`; it passed.
+- Created a local-only chart fixture in the local DB and loaded `/raids/chart-fixture-upload/sessions/0/players/Lausudo` with HTTP 200.
+- Opened the local fixture route in the in-app browser; page identity and console checks passed, but screenshot capture timed out in the browser runtime.
 - Investigated the Warmane userscript status `Sync failed: Unauthorized.`
 - Confirmed this was a Pizza Logs admin-secret rejection, not a Warmane verification failure.
 - Fixed gear and roster userscripts so production and local installs no longer share the same `pizzaLogsAdminSecret` localStorage key on `armory.warmane.com`.
@@ -104,6 +112,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
 | ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
+| Session player chart kill filter | DONE | DPS/HPS by encounter chart excludes wipes; Encounter Breakdown still lists all pulls |
 
 ## Open Follow-Ups
 

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -43,6 +43,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Short explicit marker pulls could be discarded | Marker-based encounters now bypass the heuristic minimum-event floor |
 | Heroic wipes could promote later normal kills | Non-Gunship `25N` pulls no longer inherit heroic solely from same-session evidence |
 | Saurfang/Valithria heroic labels drifted on mixed ICC raids | Removed normal-mode `Rune of Blood` as a Saurfang heroic marker, added ID-based Saurfang `Scent of Blood`, and added Valithria `Twisted Nightmares` heroic detection |
+| Session player DPS/HPS chart included wipe pulls | Chart data now uses kill encounters only while the Encounter Breakdown continues showing all pulls |
 | Cinematic intro overlay existed but stayed invisible | Replaced dynamically composed Tailwind phase class with static class strings so `frozen-intro-overlay--showing` is emitted |
 | Cinematic intro audio was missing | Render scripts preserve audio tracks, and the intro overlay now has a sound toggle while still starting muted for autoplay |
 | Missing PR Slack webhook failed PR checks | Workflow now warns and exits successfully when `PR_SLACK_WEBHOOK_URL` is absent |

--- a/app/uploads/[id]/sessions/[sessionIdx]/players/[playerName]/page.tsx
+++ b/app/uploads/[id]/sessions/[sessionIdx]/players/[playerName]/page.tsx
@@ -10,6 +10,7 @@ import { StatCard } from "@/components/ui/StatCard";
 import { getClassColor } from "@/lib/constants/classes";
 import { getClassIconUrl } from "@/lib/class-icons";
 import { getRevealClassName, getRevealStyle, orderBossDisplayEntries } from "@/lib/ui-animation";
+import { buildSessionPlayerMetricChart } from "@/lib/session-player-chart";
 import { cn, formatDps, formatDuration } from "@/lib/utils";
 
 interface Props {
@@ -122,13 +123,10 @@ export default async function SessionPlayerPage({ params }: Props) {
 
   const allPlayers = [name, ...Array.from(classmateNames)];
 
-  const chartData: ChartPoint[] = orderedEncounters.map((enc) => {
-    const point: ChartPoint = { bossName: enc.boss.name };
-    for (const pName of allPlayers) {
-      const p = enc.participants.find(part => part.player.name === pName);
-      point[pName] = p ? (metric === "DPS" ? p.dps : p.hps) : null;
-    }
-    return point;
+  const chartData: ChartPoint[] = buildSessionPlayerMetricChart({
+    encounters: orderedEncounters,
+    playerNames: allPlayers,
+    metric,
   });
 
   const chartPlayers: PlayerLine[] = allPlayers.map((pName) => ({

--- a/lib/session-player-chart.ts
+++ b/lib/session-player-chart.ts
@@ -1,0 +1,37 @@
+export type SessionPlayerMetric = "DPS" | "HPS";
+
+export type SessionPlayerChartEncounter = {
+  outcome: string;
+  boss: { name: string };
+  participants: Array<{
+    dps: number;
+    hps: number;
+    player: { name: string };
+  }>;
+};
+
+export type SessionPlayerChartPoint = {
+  bossName: string;
+  [playerName: string]: number | string | null;
+};
+
+export function buildSessionPlayerMetricChart({
+  encounters,
+  playerNames,
+  metric,
+}: {
+  encounters: SessionPlayerChartEncounter[];
+  playerNames: string[];
+  metric: SessionPlayerMetric;
+}): SessionPlayerChartPoint[] {
+  return encounters
+    .filter((encounter) => encounter.outcome === "KILL")
+    .map((encounter) => {
+      const point: SessionPlayerChartPoint = { bossName: encounter.boss.name };
+      for (const playerName of playerNames) {
+        const participant = encounter.participants.find((part) => part.player.name === playerName);
+        point[playerName] = participant ? (metric === "DPS" ? participant.dps : participant.hps) : null;
+      }
+      return point;
+    });
+}

--- a/tests/session-player-chart.test.ts
+++ b/tests/session-player-chart.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { buildSessionPlayerMetricChart } from "../lib/session-player-chart";
+
+const chart = buildSessionPlayerMetricChart({
+  encounters: [
+    {
+      boss: { name: "Lord Marrowgar" },
+      outcome: "WIPE",
+      participants: [
+        { player: { name: "Lausudo" }, dps: 3200, hps: 0 },
+        { player: { name: "Harrisj" }, dps: 500, hps: 0 },
+      ],
+    },
+    {
+      boss: { name: "Lord Marrowgar" },
+      outcome: "KILL",
+      participants: [
+        { player: { name: "Lausudo" }, dps: 8400, hps: 0 },
+        { player: { name: "Harrisj" }, dps: 400, hps: 0 },
+      ],
+    },
+    {
+      boss: { name: "Valithria Dreamwalker" },
+      outcome: "WIPE",
+      participants: [
+        { player: { name: "Lausudo" }, dps: 3800, hps: 0 },
+        { player: { name: "Harrisj" }, dps: 300, hps: 0 },
+      ],
+    },
+    {
+      boss: { name: "Deathbringer Saurfang" },
+      outcome: "KILL",
+      participants: [
+        { player: { name: "Lausudo" }, dps: 10400, hps: 0 },
+      ],
+    },
+  ],
+  playerNames: ["Lausudo", "Harrisj"],
+  metric: "DPS",
+});
+
+assert.deepEqual(
+  chart.map((point) => point.bossName),
+  ["Lord Marrowgar", "Deathbringer Saurfang"],
+);
+assert.equal(chart[0].Lausudo, 8400);
+assert.equal(chart[0].Harrisj, 400);
+assert.equal(chart[1].Lausudo, 10400);
+assert.equal(chart[1].Harrisj, null);
+
+console.log("session-player-chart tests passed");


### PR DESCRIPTION
## Summary

Removes wipe pulls from the session player DPS/HPS by encounter chart:

- adds a small `buildSessionPlayerMetricChart` helper that builds chart data from `KILL` encounters only
- keeps the Encounter Breakdown list unchanged so wipes are still visible below the graph
- adds a focused regression test proving wipe-only bosses do not appear in chart data and missing classmates remain `null` on kill pulls
- updates the vault handoff/current-focus/known-issues notes

## Validation

- Red test first: `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\session-player-chart.test.ts` failed before the helper existed
- Focused chart regression: `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\session-player-chart.test.ts`
- TypeScript: `node node_modules\typescript\bin\tsc --noEmit`
- ESLint: `node node_modules\eslint\bin\eslint.js . --max-warnings=0`
- Build: `npm run build`
- `git diff --check`
- Local rendered route with fixture data returned HTTP 200; in-app browser page identity and console checks passed, but browser screenshot capture timed out

@codex review: please focus on session player chart filtering, whether wipe data remains available in the breakdown, test coverage, and accidental secret exposure.