### PR TITLE
Refresh all gear sync players hourly

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -2,7 +2,7 @@
 
 ## Date
 
-2026-05-10
+2026-05-11
 
 ## Branch
 
@@ -23,6 +23,8 @@
   spell IDs, and Valithria heroic uses `Twisted Nightmares`.
 - Session player comparison charts now graph kills only, so wipe pulls no longer
   clutter the DPS/HPS by encounter trend.
+- Gear Sync now refreshes every known Pizza Logs character from Warmane once per
+  hour, instead of only importing players with missing or incomplete cached gear.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -49,7 +51,7 @@
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
-- Gear userscript v1.7.1 and roster userscript v1.0.5 store admin secrets per Pizza Logs target origin and show their target in the Warmane panel, so local and production secrets no longer overwrite each other on `armory.warmane.com`.
+- Gear userscript v1.8.0 requests the full refresh queue hourly; roster userscript v1.0.5 stores admin secrets per Pizza Logs target origin and shows the target in the Warmane panel, so local and production secrets no longer overwrite each other on `armory.warmane.com`.
 - The cinematic intro now uses generated video assets from `animations/source/Veo.mp4` instead of the retired `public/intro` asset set.
 
 ## Tampermonkey Auth Session
@@ -66,6 +68,21 @@
   - Gear: `1.7.1`
   - Roster: `1.0.5`
 - Local endpoints verified on `http://127.0.0.1:3001` after the local stack was started.
+
+## Hourly Gear Refresh Session
+
+- Investigated `Pizza Logs Gear Sync` reporting `No players need import or enrichment.`
+  even though Neil wanted current gear refreshed for characters already in the DB.
+- Root cause: `/api/admin/armory-gear/missing` only returned missing or
+  enrichment-needed cache rows, so complete cached characters were skipped.
+- Added a `refresh-all` mode to the existing admin gear queue endpoint.
+- Added `getArmoryGearRefreshPlayers` to return all known combat-log players plus
+  guild roster members, de-duped by character and realm.
+- Updated the hosted gear userscript and bulk bookmarklet fallback to request
+  `mode: "refresh-all"`.
+- Bumped Gear Sync to `1.8.0`.
+- Updated admin copy, README gear wording, and feature-status notes to describe
+  hourly current-equipment refreshes.
 
 ## Cinematic Intro Session
 
@@ -168,6 +185,14 @@
 | Gear/admin panel JSX-aware `ts-node` test | Passed |
 | Guild roster/admin panel JSX-aware `ts-node` test | Passed |
 | Local userscript endpoint version/key check | Passed for gear `1.7.1` and roster `1.0.5` |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-queue.test.ts` | Passed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-missing-route.test.ts` | Passed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\local-userscript-routes.test.ts` | Passed |
+| JSX-aware `tests\gear-import-bookmarklet.test.ts` | Passed |
+| `node node_modules\typescript\bin\tsc --noEmit` | Passed |
+| `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
+| `npm run build` | Passed |
 | `node node_modules\typescript\bin\tsc --noEmit` | Passed |
 | `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
 | `npm run build` | Passed |
@@ -190,11 +215,13 @@
 - `pull_request_target` runs the Slack workflow from `main`, so Slack formatting changes only affect fresh PR events after the workflow update is merged.
 - Absorbs remain future parser work.
 - Railway CLI is installed locally but this checkout remains unlinked until Neil intentionally runs `railway link`.
+- Hourly full gear refresh depends on a browser tab visiting Warmane with the
+  production Gear Sync userscript installed and the correct admin secret saved.
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR for the ICC difficulty marker fix and the
-session player chart kill-only update. After deployment, reprocess or re-upload
-the affected latest raid so the stored Deathbringer Saurfang and Valithria
-Dreamwalker rows are regenerated with the correct difficulties. Neil merges into
-`main` only after review; Codex does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR for the hourly Gear Sync refresh update.
+After deployment, reinstall/update the production Gear Sync userscript from
+`/admin`, open any Warmane character page, and click `Sync now` once if the
+admin secret is not already saved. Neil merges into `main` only after review;
+Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session fixed latest mixed-ICC difficulty drift and removed wipe pulls from the session player DPS/HPS by encounter chart. Deathbringer Saurfang no longer upgrades to heroic from normal-mode `Rune of Blood`, and Valithria Dreamwalker now upgrades to heroic from `Twisted Nightmares` evidence. Parser reliability remains the highest-risk product area.
+The current session updated Warmane Gear Sync so hourly runs refresh every known Pizza Logs character from Warmane instead of only importing missing or incomplete gear rows. Gear Sync is now `1.8.0` and sends `mode: "refresh-all"` to the admin gear queue endpoint. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -14,6 +14,18 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Investigated the Gear Sync status `No players need import or enrichment.` after Neil clarified that existing DB players should be updated to their current Warmane gear.
+- Confirmed the existing queue only returned missing or enrichment-needed cached gear rows.
+- Added a refresh-all queue helper that returns all known combat-log players plus PizzaWarriors/Lordaeron roster members, de-duped by character and realm.
+- Added `mode: "refresh-all"` support to `/api/admin/armory-gear/missing`; missing-only behavior remains the default for compatibility.
+- Updated the Gear Sync userscript hourly path and the bulk bookmarklet fallback to request refresh-all mode.
+- Bumped the Gear Sync userscript to `1.8.0`.
+- Updated admin copy, README gear wording, feature status, and known-issues notes for hourly current-equipment refreshes.
+- Added focused tests for the refresh-all queue, route behavior, userscript request body, bookmarklet fallback, and admin panel copy.
+- Ran the focused gear sync tests and local userscript route test; they passed after the implementation.
+- Ran `node node_modules\typescript\bin\tsc --noEmit`; it passed.
+- Ran `node node_modules\eslint\bin\eslint.js . --max-warnings=0`; it passed.
+- Ran `npm run build`; it passed.
 - Investigated the latest raid report where Deathbringer Saurfang was normal but displayed heroic, and Valithria Dreamwalker was heroic but displayed normal.
 - Confirmed the parser treated `Rune of Blood` as heroic evidence even though it appears in normal Saurfang.
 - Confirmed Valithria had no heroic marker for `Twisted Nightmares`.
@@ -111,6 +123,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | README app preview | DONE | Added `docs/assets/readme-screenshot.png` and linked it from `README.md` |
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
+| Hourly Gear Sync refresh-all | DONE | Gear `1.8.0` refreshes all known DB/roster characters hourly from Warmane |
 | ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
 | Session player chart kill filter | DONE | DPS/HPS by encounter chart excludes wipes; Encounter Breakdown still lists all pulls |
 
@@ -121,7 +134,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Continue using browser-assisted Warmane imports until a local automated sync agent is built.
-- After the userscript auth PR deploys, reinstall/update the production gear and roster userscripts from `/admin`; local `3001` variants are already serving the new scripts while the local server is running.
+- After the hourly refresh PR deploys, reinstall/update the production Gear Sync userscript from `/admin`; open any Warmane character page and click `Sync now` once if the admin secret is not saved.
 - After this parser fix deploys, reprocess or re-upload the affected latest raid so stored Saurfang and Valithria difficulties are regenerated.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.

--- a/Pizza Logs HQ/05 Features/Feature Status.md
+++ b/Pizza Logs HQ/05 Features/Feature Status.md
@@ -20,7 +20,7 @@ This file is the single source for shipped features, active backlog, and technic
 | Header search | Searches combat-log players plus roster-only members through `/api/players/search` |
 | Gear cache | Warmane snapshots cached in `armory_gear_cache`, with GearScoreLite display |
 | Item metadata | AzerothCore `item_template` import populates `wow_items`; no runtime Wowhead API dependency |
-| Gear/userscript import | Browser-assisted Warmane Gear Sync fills gear snapshots and icon gaps |
+| Gear/userscript import | Browser-assisted Warmane Gear Sync refreshes known character gear hourly and fills icon gaps |
 | Class-icon avatars | Player avatars use WoW class icons with initials fallback |
 | ICC ordering | Shared helpers keep ICC boss displays in progression order where appropriate |
 | Local test server helpers | Windows scripts start/stop web and parser test servers |

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -51,6 +51,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | PR Slack message read like a raw dump | Reworked Slack blocks into a compact header, metadata fields, trimmed description, and cleaner changed-file list |
 | PR description headings showed unsupported Slack markdown | Added markdown normalization so GitHub headings become Slack bold labels |
 | Local and production Warmane userscripts shared the same saved admin secret | Gear `1.7.1` and roster `1.0.5` now use target-specific localStorage keys, show the target host, and clear the legacy shared key on unauthorized responses |
+| Gear Sync skipped already cached characters | Gear `1.8.0` requests refresh-all mode hourly so complete cached players are refreshed from Warmane too |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Player profiles merge:
 
 Warmane live server fetches are best-effort and may fail from Railway or local scripts because of Cloudflare/403 behavior. The supported operational path is browser-assisted import from `/admin`:
 
-- Warmane Gear Sync userscript for character equipment and icon backfill.
+- Warmane Gear Sync userscript for hourly current-equipment refreshes and icon backfill.
 - Warmane Guild Roster userscript for roster rank, class, race, professions, and member rows.
 
 Player avatars intentionally use class icons instead of Warmane-rendered character portraits. The old portrait userscript URL remains only as a no-op compatibility update for existing installs.

--- a/app/admin/GearImportBookmarklet.tsx
+++ b/app/admin/GearImportBookmarklet.tsx
@@ -7,9 +7,9 @@ export function GearImportBookmarklet() {
         <h3 className="heading-cinzel text-sm text-gold tracking-wide">Browser Gear Import</h3>
         <p className="text-sm text-text-secondary mt-1">
           Install the hosted userscript with Tampermonkey, then open Warmane Armory. It adds a
-          small Pizza Logs sync panel and automatically imports missing or unenriched players
-          through Warmane&apos;s browser-accessible API. The admin secret is stored in browser
-          localStorage on Warmane so auto-sync can run.
+          small Pizza Logs sync panel and refreshes every known Pizza Logs character once per
+          hour through Warmane&apos;s browser-accessible API. The admin secret is stored in
+          browser localStorage on Warmane so auto-sync can run.
         </p>
       </div>
       <ol className="list-decimal space-y-1 pl-5 text-sm text-text-secondary">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -183,7 +183,7 @@ export default async function AdminPage() {
           <p className="text-sm text-text-secondary max-w-3xl">
             Player pages read gear from this database cache. Railway cannot reliably fetch
             Warmane directly, so use the browser importer below from a Warmane Armory
-            character page to fill missing snapshots.
+            character page to refresh known characters with their current equipment.
           </p>
           <GearImportBookmarklet />
         </div>

--- a/app/api/admin/armory-gear/missing/route.ts
+++ b/app/api/admin/armory-gear/missing/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { DEFAULT_GUILD_NAME, DEFAULT_GUILD_REALM } from "@/lib/warmane-guild-roster";
-import { getMissingArmoryGearPlayers } from "@/lib/armory-gear-queue";
+import { getArmoryGearRefreshPlayers, getMissingArmoryGearPlayers } from "@/lib/armory-gear-queue";
 import { verifyAdminSecretValue } from "@/lib/admin-auth";
 
 const MAX_PLAYERS = 100;
@@ -50,6 +50,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!verifyAdmin(payload.secret)) {
     return NextResponse.json({ ok: false, error: "Unauthorized." }, { status: 401, headers });
   }
+  const mode = payload.mode === "refresh-all" ? "refresh-all" : "missing";
 
   const players = await db.player.findMany({
     orderBy: { name: "asc" },
@@ -72,6 +73,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       realm: true,
     },
   });
+
+  if (mode === "refresh-all") {
+    const refreshPlayers = getArmoryGearRefreshPlayers({ players, rosterMembers });
+    return NextResponse.json({ ok: true, mode, players: refreshPlayers }, { headers });
+  }
+
   const queueKeys = Array.from(new Set([
     ...players.map(player => player.name.toLowerCase()),
     ...rosterMembers.map(member => member.normalizedCharacterName),
@@ -89,5 +96,5 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   });
   const missing = getMissingArmoryGearPlayers({ players, rosterMembers, cachedRows }).slice(0, MAX_PLAYERS);
 
-  return NextResponse.json({ ok: true, players: missing }, { headers });
+  return NextResponse.json({ ok: true, mode, players: missing }, { headers });
 }

--- a/lib/armory-gear-client-scripts.ts
+++ b/lib/armory-gear-client-scripts.ts
@@ -147,11 +147,11 @@ export function buildBookmarklet(): string {
       throw new Error(lastError);
     };
 
-    postJson(`${pizzaLogsOrigin}/api/admin/armory-gear/missing`, { secret })
+    postJson(`${pizzaLogsOrigin}/api/admin/armory-gear/missing`, { secret, mode: "refresh-all" })
       .then(async (queue) => {
         const players = queue.players || [];
         if (players.length === 0) {
-          alert("Pizza Logs: no players need gear import or enrichment.");
+          alert("Pizza Logs: no Pizza Logs players found to refresh.");
           return;
         }
 
@@ -174,7 +174,7 @@ export function buildBookmarklet(): string {
         const suffix = failed.length > 0
           ? `\n\nFailed after retries (${failed.length}):\n${failedPreview}${failed.length > 8 ? "\n..." : ""}`
           : "";
-        alert(`Pizza Logs: imported ${cached}; failed ${failed.length}.${suffix}`);
+        alert(`Pizza Logs: refreshed ${cached}; failed ${failed.length}.${suffix}`);
       })
       .catch((error) => {
         alert(`Pizza Logs import failed: ${error.message}`);
@@ -566,20 +566,20 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
       if (state.button) state.button.disabled = true;
 
       try {
-        setStatus("Checking Pizza Logs queue...");
-        const queue = await postJson(`${pizzaLogsOrigin}/api/admin/armory-gear/missing`, { secret });
+        setStatus("Refreshing known Pizza Logs players...");
+        const queue = await postJson(`${pizzaLogsOrigin}/api/admin/armory-gear/missing`, { secret, mode: "refresh-all" });
         const players = queue.players || [];
 
         if (players.length === 0) {
           localStorage.setItem(lastRunKey, String(Date.now()));
-          setStatus("No players need import or enrichment.");
+          setStatus("No Pizza Logs players found to refresh.");
           return;
         }
 
         let imported = 0;
         const failed: string[] = [];
         for (const player of players) {
-          setStatus(`Importing ${player.characterName} (${imported + failed.length + 1}/${players.length})...`);
+          setStatus(`Refreshing ${player.characterName} (${imported + failed.length + 1}/${players.length})...`);
           try {
             await importPlayer(player, secret);
             imported++;
@@ -590,7 +590,7 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
         }
 
         localStorage.setItem(lastRunKey, String(Date.now()));
-        setStatus(`Imported ${imported}; failed ${failed.length}${failed.length ? `. ${failed.slice(0, 3).join("; ")}` : "."}`);
+        setStatus(`Refreshed ${imported}; failed ${failed.length}${failed.length ? `. ${failed.slice(0, 3).join("; ")}` : "."}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (message === "Unauthorized.") {
@@ -623,8 +623,8 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Gear Auto Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.7.1",
-    "// @description  Automatically sync Pizza Logs gear cache from Warmane Armory pages.",
+    "// @version      1.8.0",
+    "// @description  Hourly refresh Pizza Logs gear cache from Warmane Armory pages.",
     "// @match        https://armory.warmane.com/character/*",
     "// @match        http://armory.warmane.com/character/*",
     `// @downloadURL   ${userscriptUrl}`,

--- a/lib/armory-gear-queue.ts
+++ b/lib/armory-gear-queue.ts
@@ -23,17 +23,15 @@ export type ArmoryGearQueueEntry = {
 };
 
 function queueKey(characterName: string, realm: string): string {
-  return `${characterName.trim().toLowerCase()}:${realm}`;
+  return `${characterName.trim().toLowerCase()}:${realm.trim().toLowerCase()}`;
 }
 
-export function getMissingArmoryGearPlayers({
+function getKnownArmoryGearEntries({
   players,
   rosterMembers,
-  cachedRows,
 }: {
   players: ArmoryGearQueuePlayer[];
   rosterMembers: ArmoryGearQueueRosterMember[];
-  cachedRows: ArmoryGearQueueCachedRow[];
 }): ArmoryGearQueueEntry[] {
   const entries = new Map<string, ArmoryGearQueueEntry>();
 
@@ -52,13 +50,38 @@ export function getMissingArmoryGearPlayers({
     });
   }
 
+  return Array.from(entries.values())
+    .sort((left, right) => left.characterName.localeCompare(right.characterName));
+}
+
+export function getArmoryGearRefreshPlayers({
+  players,
+  rosterMembers,
+}: {
+  players: ArmoryGearQueuePlayer[];
+  rosterMembers: ArmoryGearQueueRosterMember[];
+}): ArmoryGearQueueEntry[] {
+  return getKnownArmoryGearEntries({ players, rosterMembers });
+}
+
+export function getMissingArmoryGearPlayers({
+  players,
+  rosterMembers,
+  cachedRows,
+}: {
+  players: ArmoryGearQueuePlayer[];
+  rosterMembers: ArmoryGearQueueRosterMember[];
+  cachedRows: ArmoryGearQueueCachedRow[];
+}): ArmoryGearQueueEntry[] {
+  const entries = getKnownArmoryGearEntries({ players, rosterMembers });
+
   const freshCachedKeys = new Set(
     cachedRows
       .filter((row) => !gearNeedsEnrichment(row.gear))
       .map((row) => queueKey(row.characterKey, row.realm))
   );
 
-  return Array.from(entries.values())
+  return entries
     .filter((entry) => !freshCachedKeys.has(queueKey(entry.characterName, entry.realm)))
     .sort((left, right) => left.characterName.localeCompare(right.characterName));
 }

--- a/tests/armory-gear-client-scripts.test.ts
+++ b/tests/armory-gear-client-scripts.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import vm from "node:vm";
 import { buildGuildRosterUserscript } from "../lib/guild-roster-client-scripts";
 import {
+  buildBookmarklet,
   buildUserscript,
   LOCAL_USERSCRIPT_PATH,
   LOCAL_USERSCRIPT_URL,
@@ -11,6 +12,7 @@ import {
   USERSCRIPT_URL,
 } from "../lib/armory-gear-client-scripts";
 
+const bookmarklet = buildBookmarklet();
 const userscript = buildUserscript();
 const localUserscript = buildUserscript({
   pizzaLogsOrigin: PIZZA_LOGS_LOCAL_ORIGIN,
@@ -34,7 +36,7 @@ assert.match(localUserscript, new RegExp(`// @downloadURL\\s+${LOCAL_USERSCRIPT_
 assert.match(localUserscript, new RegExp(`// @updateURL\\s+${LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 assert.match(localUserscript, new RegExp(`const pizzaLogsOrigin = "${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}";`));
 assert.match(localUserscript, /\/api\/admin\/armory-gear\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.7\.1/);
+assert.match(userscript, /\/\/ @version\s+1\.8\.0/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/character\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/character\/\*/);
 assert.match(userscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
@@ -54,6 +56,10 @@ assert.match(userscript, /DOMContentLoaded/);
 assert.match(userscript, /Pizza Logs userscript starting/);
 assert.match(userscript, /Pizza Logs panel injection failed/);
 assert.match(userscript, /Pizza Logs Gear Sync/);
+assert.match(userscript, /Refreshing known Pizza Logs players/);
+assert.match(userscript, /mode: "refresh-all"/);
+assert.match(bookmarklet, /mode: "refresh-all"/);
+assert.match(bookmarklet, /no Pizza Logs players found to refresh/i);
 
 const rosterUserscript = buildGuildRosterUserscript();
 const gearBottom = userscript.match(/"bottom:([^"]+)"/)?.[1];
@@ -65,6 +71,7 @@ assert.notEqual(gearBottom, rosterBottom);
 async function verifyUserscriptMergesDomIconFallback() {
   const pending: Promise<unknown>[] = [];
   const importBodies: Array<{ equipment?: Array<{ item?: string; iconUrl?: string }> }> = [];
+  const queueBodies: Array<{ mode?: string }> = [];
   const storage = new Map<string, string>([
     [`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN}`, "secret"],
     [`pizzaLogsLastGearSyncAt:${PIZZA_LOGS_ORIGIN}`, "0"],
@@ -114,6 +121,7 @@ async function verifyUserscriptMergesDomIconFallback() {
     },
     fetch: async (url: string, init?: { body?: string }) => {
       if (url.endsWith("/api/admin/armory-gear/missing")) {
+        queueBodies.push(JSON.parse(init?.body ?? "{}"));
         return { ok: true, json: async () => ({ ok: true, players: [{ characterName: "Lausudo", realm: "Lordaeron" }] }) };
       }
       if (url.includes("/api/character/Lausudo/Lordaeron/summary")) {
@@ -133,6 +141,7 @@ async function verifyUserscriptMergesDomIconFallback() {
   }
 
   assert.equal(importBodies.length, 1);
+  assert.equal(queueBodies[0]?.mode, "refresh-all");
   assert.equal(
     importBodies[0].equipment?.[0]?.iconUrl,
     "https://wow.zamimg.com/images/wow/icons/large/inv_chest_plate_26.jpg",
@@ -142,6 +151,7 @@ async function verifyUserscriptMergesDomIconFallback() {
 async function verifyUserscriptFetchesQueuedPlayerPageIcons() {
   const pending: Promise<unknown>[] = [];
   const importBodies: Array<{ equipment?: Array<{ item?: string; iconUrl?: string }> }> = [];
+  const queueBodies: Array<{ mode?: string }> = [];
   const storage = new Map<string, string>([
     [`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN}`, "secret"],
     [`pizzaLogsLastGearSyncAt:${PIZZA_LOGS_ORIGIN}`, "0"],
@@ -200,6 +210,7 @@ async function verifyUserscriptFetchesQueuedPlayerPageIcons() {
     },
     fetch: async (url: string, init?: { body?: string }) => {
       if (url.endsWith("/api/admin/armory-gear/missing")) {
+        queueBodies.push(JSON.parse(init?.body ?? "{}"));
         return { ok: true, json: async () => ({ ok: true, players: [{ characterName: "Maxximusboom", realm: "Lordaeron" }] }) };
       }
       if (url.includes("/api/character/Maxximusboom/Lordaeron/summary")) {
@@ -222,6 +233,7 @@ async function verifyUserscriptFetchesQueuedPlayerPageIcons() {
   }
 
   assert.equal(importBodies.length, 1);
+  assert.equal(queueBodies[0]?.mode, "refresh-all");
   assert.equal(
     importBodies[0].equipment?.[0]?.iconUrl,
     "https://wow.zamimg.com/images/wow/icons/large/inv_helmet_158.jpg",

--- a/tests/armory-gear-missing-route.test.ts
+++ b/tests/armory-gear-missing-route.test.ts
@@ -32,7 +32,8 @@ const dbCalls: {
   players?: FindManyArgs;
   rosterMembers?: FindManyArgs;
   cachedRows?: FindManyArgs;
-} = {};
+  cachedRowsCount: number;
+} = { cachedRowsCount: 0 };
 
 function applyTake<T>(rows: T[], args: FindManyArgs): T[] {
   return typeof args.take === "number" ? rows.slice(0, args.take) : rows;
@@ -57,6 +58,7 @@ const db = {
   armoryGearCache: {
     findMany: async (args: FindManyArgs) => {
       dbCalls.cachedRows = args;
+      dbCalls.cachedRowsCount++;
       return freshCachedRows;
     },
   },
@@ -116,8 +118,30 @@ async function main() {
     assert.deepEqual(payload.players, [
       { characterName: "Maxximusboom", realm: "Lordaeron" },
     ]);
+    assert.equal(payload.mode, "missing");
     assert.equal(dbCalls.players?.take, undefined);
     assert.equal(dbCalls.rosterMembers?.take, undefined);
+
+    dbCalls.cachedRowsCount = 0;
+    const refreshResponse = await POST(new Request("https://pizza-logs.test/api/admin/armory-gear/missing", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://armory.warmane.com",
+      },
+      body: JSON.stringify({ secret: "test-secret", mode: "refresh-all" }),
+    }) as never);
+    const refreshPayload = await refreshResponse.json();
+
+    assert.equal(refreshResponse.status, 200);
+    assert.equal(refreshPayload.mode, "refresh-all");
+    assert.equal(refreshPayload.players.length, 121);
+    assert.deepEqual(refreshPayload.players.slice(0, 2), [
+      { characterName: "Fresh000", realm: "Lordaeron" },
+      { characterName: "Fresh001", realm: "Lordaeron" },
+    ]);
+    assert.deepEqual(refreshPayload.players.at(-1), { characterName: "Maxximusboom", realm: "Lordaeron" });
+    assert.equal(dbCalls.cachedRowsCount, 0);
   } finally {
     moduleLoader._resolveFilename = originalResolve;
     delete require.cache[dbMockPath];

--- a/tests/armory-gear-queue.test.ts
+++ b/tests/armory-gear-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { getMissingArmoryGearPlayers } from "../lib/armory-gear-queue";
+import { getArmoryGearRefreshPlayers, getMissingArmoryGearPlayers } from "../lib/armory-gear-queue";
 
 const missing = getMissingArmoryGearPlayers({
   players: [
@@ -102,6 +102,23 @@ const lateMissing = getMissingArmoryGearPlayers({
 
 assert.deepEqual(lateMissing, [
   { characterName: "Maxximusboom", realm: "Lordaeron" },
+]);
+
+const refreshPlayers = getArmoryGearRefreshPlayers({
+  players: [
+    { name: "Lausudo", realm: { name: "Lordaeron" } },
+    { name: "Behemouth", realm: { name: "Lordaeron" } },
+  ],
+  rosterMembers: [
+    { characterName: "Maximusboom", normalizedCharacterName: "maximusboom", realm: "Lordaeron" },
+    { characterName: "Lausudo", normalizedCharacterName: "lausudo", realm: "Lordaeron" },
+  ],
+});
+
+assert.deepEqual(refreshPlayers, [
+  { characterName: "Behemouth", realm: "Lordaeron" },
+  { characterName: "Lausudo", realm: "Lordaeron" },
+  { characterName: "Maximusboom", realm: "Lordaeron" },
 ]);
 
 console.log("armory-gear-queue tests passed");

--- a/tests/gear-import-bookmarklet.test.ts
+++ b/tests/gear-import-bookmarklet.test.ts
@@ -7,6 +7,7 @@ import { LOCAL_USERSCRIPT_URL, USERSCRIPT_URL } from "../lib/armory-gear-client-
 const markup = renderToStaticMarkup(React.createElement(GearImportBookmarklet));
 
 assert.match(markup, /Browser Gear Import/);
+assert.match(markup, /refreshes every known Pizza Logs character once per hour/);
 assert.match(markup, new RegExp(USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 assert.match(markup, new RegExp(LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 assert.match(markup, /Install \/ Update Gear Userscript/);


### PR DESCRIPTION
## Summary
- Add refresh-all mode to the admin gear queue so cached characters are returned for refresh too.
- Update Gear Sync userscript/bookmarklet to request refresh-all mode every hourly run and bump gear script to 1.8.0.
- Refresh admin/README/vault wording and tests around hourly current-gear sync.

## Validation
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-queue.test.ts
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-missing-route.test.ts
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\local-userscript-routes.test.ts
- JSX-aware tests\gear-import-bookmarklet.test.ts
- node node_modules\typescript\bin\tsc --noEmit
- node node_modules\eslint\bin\eslint.js . --max-warnings=0
- npm run build

## Deployment notes
- No Prisma migration or environment variable changes.
- After merge/deploy, reinstall/update Gear Sync from /admin so Tampermonkey picks up version 1.8.0.