### PR TITLE
Add Windows Gear Sync scheduler

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -25,6 +25,8 @@
   clutter the DPS/HPS by encounter trend.
 - Gear Sync now refreshes every known Pizza Logs character from Warmane once per
   hour, instead of only importing players with missing or incomplete cached gear.
+- Local Windows automation can now open a Warmane character page hourly and at
+  logon so the browser Gear Sync userscript can run after restarts.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -52,6 +54,8 @@
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
 - Gear userscript v1.8.0 requests the full refresh queue hourly; roster userscript v1.0.5 stores admin secrets per Pizza Logs target origin and shows the target in the Warmane panel, so local and production secrets no longer overwrite each other on `armory.warmane.com`.
+- Windows gear automation scripts live under `scripts/gear-sync/`; docs live in
+  `docs/gear-sync-windows-task.md`.
 - The cinematic intro now uses generated video assets from `animations/source/Veo.mp4` instead of the retired `public/intro` asset set.
 
 ## Tampermonkey Auth Session
@@ -83,6 +87,27 @@
 - Bumped Gear Sync to `1.8.0`.
 - Updated admin copy, README gear wording, and feature-status notes to describe
   hourly current-equipment refreshes.
+
+## Windows Gear Sync Task Session
+
+- Confirmed direct local CLI/API requests to Warmane character JSON return HTTP
+  403, so the safe automation path still needs a real browser context.
+- Added `scripts/gear-sync/open-warmane-gear-sync.ps1` to open a configurable
+  Warmane character page with Chrome, Edge, or the Windows default browser.
+- Added `scripts/gear-sync/install-windows-task.ps1` to register the hourly
+  `PizzaLogsGearSync` task through `schtasks.exe` and create a Startup-folder
+  `PizzaLogsGearSyncAtLogon.cmd` launcher.
+- Added `scripts/gear-sync/uninstall-windows-task.ps1` for cleanup.
+- Added npm shortcuts:
+  - `npm run gear-sync:install-task`
+  - `npm run gear-sync:uninstall-task`
+- Added `docs/gear-sync-windows-task.md` with setup, limits, logs, Startup
+  folder behavior, and uninstall instructions.
+- The scheduled task stores no Pizza Logs admin secret; the userscript secret
+  remains in the browser profile on `armory.warmane.com`.
+- Installed the current-user hourly scheduled task on Neil's Windows machine.
+- Created the Startup-folder launcher at
+  `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd`.
 
 ## Cinematic Intro Session
 
@@ -178,6 +203,12 @@
 | `node node_modules\typescript\bin\tsc --noEmit` | Passed |
 | `node node_modules\eslint\bin\eslint.js . --max-warnings=0` | Passed |
 | `npm run build` | Passed |
+| Local Warmane API probe from PowerShell | Returned expected HTTP 403, confirming browser-assisted automation is still needed |
+| `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts` | Passed |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1 -WhatIf` | Passed |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1` | Passed; registered `PizzaLogsGearSync` and created Startup launcher |
+| `schtasks.exe /Query /TN PizzaLogsGearSync /FO LIST /V` | Passed; task is ready and repeats every 1 hour |
+| Startup launcher content check | Passed; points at `scripts\gear-sync\open-warmane-gear-sync.ps1` |
 | Local `GET http://127.0.0.1:3001/guild-roster?page=2` | Passed with HTTP 200 after dev server compile |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed |
@@ -215,13 +246,16 @@
 - `pull_request_target` runs the Slack workflow from `main`, so Slack formatting changes only affect fresh PR events after the workflow update is merged.
 - Absorbs remain future parser work.
 - Railway CLI is installed locally but this checkout remains unlinked until Neil intentionally runs `railway link`.
-- Hourly full gear refresh depends on a browser tab visiting Warmane with the
-  production Gear Sync userscript installed and the correct admin secret saved.
+- Hourly full gear refresh depends on a local Windows user/browser profile with
+  the production Gear Sync userscript installed and the correct admin secret saved.
+- The current-user task is interactive only. It persists through restarts, but it
+  cannot run before Neil logs into Windows.
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR for the hourly Gear Sync refresh update.
+Review the `codex-dev` to `main` PR for the local Windows Gear Sync automation.
 After deployment, reinstall/update the production Gear Sync userscript from
 `/admin`, open any Warmane character page, and click `Sync now` once if the
-admin secret is not already saved. Neil merges into `main` only after review;
-Codex does not merge or push `main` directly.
+admin secret is not already saved. The scheduled task can then keep opening
+Warmane hourly after restarts. Neil merges into `main` only after review; Codex
+does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session updated Warmane Gear Sync so hourly runs refresh every known Pizza Logs character from Warmane instead of only importing missing or incomplete gear rows. Gear Sync is now `1.8.0` and sends `mode: "refresh-all"` to the admin gear queue endpoint. Parser reliability remains the highest-risk product area.
+The current session added local Windows automation for Gear Sync. Direct local CLI requests to Warmane still return 403, so the automation opens a real Warmane character page hourly and at Windows logon; the browser Gear Sync userscript handles the actual refresh. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -26,6 +26,16 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Ran `node node_modules\typescript\bin\tsc --noEmit`; it passed.
 - Ran `node node_modules\eslint\bin\eslint.js . --max-warnings=0`; it passed.
 - Ran `npm run build`; it passed.
+- Probed Warmane character JSON with local PowerShell and confirmed it returns HTTP 403 outside a browser context.
+- Added Windows Gear Sync automation scripts under `scripts/gear-sync/`.
+- Added `npm run gear-sync:install-task` and `npm run gear-sync:uninstall-task`.
+- Added `docs/gear-sync-windows-task.md`.
+- Added `tests/gear-sync-windows-task-source.test.ts` to verify the task scripts, docs, npm commands, and no scheduled-task secret storage.
+- Ran the new source test; it failed before the scripts existed and passed after implementation.
+- Ran the install script with `-WhatIf`; the PowerShell ScheduledTasks API path hit access issues, so the installer now uses `schtasks.exe` for the hourly task and a Startup-folder command file for logon.
+- Installed the actual `PizzaLogsGearSync` hourly task on Neil's Windows machine.
+- Created `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd`.
+- Queried the scheduled task and startup launcher; both point at `scripts\gear-sync\open-warmane-gear-sync.ps1`.
 - Investigated the latest raid report where Deathbringer Saurfang was normal but displayed heroic, and Valithria Dreamwalker was heroic but displayed normal.
 - Confirmed the parser treated `Rune of Blood` as heroic evidence even though it appears in normal Saurfang.
 - Confirmed Valithria had no heroic marker for `Twisted Nightmares`.
@@ -124,6 +134,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
 | Hourly Gear Sync refresh-all | DONE | Gear `1.8.0` refreshes all known DB/roster characters hourly from Warmane |
+| Windows Gear Sync scheduled task | DONE | Task Scheduler opens a Warmane character page hourly; Startup folder opens it at logon |
 | ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
 | Session player chart kill filter | DONE | DPS/HPS by encounter chart excludes wipes; Encounter Breakdown still lists all pulls |
 
@@ -133,8 +144,8 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Confirm the fresh docs-only PR posts to Slack now that `PR_SLACK_WEBHOOK_URL` is configured.
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
-- Continue using browser-assisted Warmane imports until a local automated sync agent is built.
-- After the hourly refresh PR deploys, reinstall/update the production Gear Sync userscript from `/admin`; open any Warmane character page and click `Sync now` once if the admin secret is not saved.
+- Use `scripts/gear-sync/install-windows-task.ps1` or `npm run gear-sync:install-task` to keep Gear Sync running hourly from Windows.
+- After the Windows automation PR deploys, reinstall/update the production Gear Sync userscript from `/admin`; open any Warmane character page and click `Sync now` once if the admin secret is not saved.
 - After this parser fix deploys, reprocess or re-upload the affected latest raid so stored Saurfang and Valithria difficulties are regenerated.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.

--- a/Pizza Logs HQ/05 Features/Feature Status.md
+++ b/Pizza Logs HQ/05 Features/Feature Status.md
@@ -21,6 +21,7 @@ This file is the single source for shipped features, active backlog, and technic
 | Gear cache | Warmane snapshots cached in `armory_gear_cache`, with GearScoreLite display |
 | Item metadata | AzerothCore `item_template` import populates `wow_items`; no runtime Wowhead API dependency |
 | Gear/userscript import | Browser-assisted Warmane Gear Sync refreshes known character gear hourly and fills icon gaps |
+| Windows gear sync task | Task Scheduler opens Warmane hourly and Startup folder opens it at logon so Gear Sync can run after restarts |
 | Class-icon avatars | Player avatars use WoW class icons with initials fallback |
 | ICC ordering | Shared helpers keep ICC boss displays in progression order where appropriate |
 | Local test server helpers | Windows scripts start/stop web and parser test servers |
@@ -31,7 +32,7 @@ This file is the single source for shipped features, active backlog, and technic
 
 | Item | Status |
 |---|---|
-| Warmane production data freshness | Manual/browser-assisted until local automated sync agent exists |
+| Warmane production data freshness | Browser-assisted Windows Task Scheduler automation is available; fully headless sync remains future work |
 | Absorbs | Future parser work; not currently implemented |
 
 ## Backlog
@@ -53,7 +54,7 @@ This file is the single source for shipped features, active backlog, and technic
 
 | Debt | Impact | Fix |
 |---|---|---|
-| Manual Warmane sync | Gear/roster can go stale | Local automated sync agent with snapshot validation |
+| Browser-dependent Warmane sync | Gear refresh depends on a logged-in Windows browser profile | Future fully headless local sync agent if Warmane access allows it |
 | Upload lacks hard size cap | Large uploads can waste resources | Enforce size during upload/forwarding |
 | Role inference is rough | Hybrids and tanks can be mislabeled | Use better class/spec/combat evidence |
 | Encounter detail links to global player profile | Different navigation from session pages | Pass upload/session context where needed |

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -12,7 +12,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Upload rate limiting is not implemented | Abuse could create parser/DB load | Prefer Railway-level controls first; add app logic only if needed |
 | Absorbs are not implemented | Disc priest contribution can be lower than Skada combined healing+absorbs views | Future parser work based on Skada `Absorbs.lua`; keep separate from healing done |
 | Role detection is rough | Hybrids/self-healing classes can be mislabeled; tanks are not inferred | Replace upload-time heal/damage ratio with better class/spec/combat evidence |
-| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway | Supported path is browser-assisted userscripts and cached DB snapshots |
+| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway or plain CLI requests | Supported path is browser-assisted userscripts, Windows Task Scheduler launch, and cached DB snapshots |
 | Some heroic/Gunship difficulty evidence is absent | Certain pulls cannot be classified perfectly from logs alone | Use direct marker evidence first; keep normal-looking non-Gunship fallback attempts normal; document uncertainty |
 | Orphaned pets can remain unmatched | Small DPS mismatches when pets were active before log start | Keep Skada-aligned owner remap when summon evidence exists |
 
@@ -52,6 +52,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | PR description headings showed unsupported Slack markdown | Added markdown normalization so GitHub headings become Slack bold labels |
 | Local and production Warmane userscripts shared the same saved admin secret | Gear `1.7.1` and roster `1.0.5` now use target-specific localStorage keys, show the target host, and clear the legacy shared key on unauthorized responses |
 | Gear Sync skipped already cached characters | Gear `1.8.0` requests refresh-all mode hourly so complete cached players are refreshed from Warmane too |
+| Gear Sync only ran when Neil manually visited Warmane | Added Windows automation that opens a Warmane character page hourly through Task Scheduler and at logon through the Startup folder |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Warmane live server fetches are best-effort and may fail from Railway or local s
 - Warmane Gear Sync userscript for hourly current-equipment refreshes and icon backfill.
 - Warmane Guild Roster userscript for roster rank, class, race, professions, and member rows.
 
+For Windows persistence, the repo includes a Task Scheduler setup that opens a
+Warmane character page hourly so the Gear Sync userscript can run after restarts:
+[`docs/gear-sync-windows-task.md`](docs/gear-sync-windows-task.md).
+
 Player avatars intentionally use class icons instead of Warmane-rendered character portraits. The old portrait userscript URL remains only as a no-op compatibility update for existing installs.
 
 Item names, item levels, stats, slot metadata, and GearScoreLite inputs come from the local AzerothCore `item_template` import:

--- a/docs/gear-sync-windows-task.md
+++ b/docs/gear-sync-windows-task.md
@@ -1,0 +1,91 @@
+# Windows Gear Sync Automation
+
+Pizza Logs can run Warmane gear refreshes from Neil's Windows PC without putting
+anything on Railway. Warmane blocks plain server-side and CLI requests with 403,
+so the local automation opens a real Warmane character page and lets the
+Tampermonkey Gear Sync userscript do the refresh from the browser.
+
+This setup persists through restarts by combining one hourly Task Scheduler task
+with one Startup folder launcher. Both run when the Windows user is logged in.
+
+## What It Does
+
+- Opens a Warmane character page once per hour.
+- Opens the same page at Windows logon from the Startup folder.
+- Relies on the installed Pizza Logs Gear Sync userscript to refresh all known
+  Pizza Logs characters.
+- Writes launcher logs to `.sync-agent-logs/gear-sync-launcher.log`.
+
+The scheduled task does not store the Pizza Logs admin secret, `DATABASE_URL`,
+Railway tokens, or other production secrets. The admin secret remains wherever
+the browser userscript stores it for `armory.warmane.com`.
+
+## Prerequisites
+
+1. Install or update the production Gear Sync userscript from `/admin`.
+2. Open a Warmane character page.
+3. Click `Sync now` once and enter the production admin secret.
+4. Confirm Gear Sync shows the production target.
+
+## Install The Task
+
+From the repo root:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1
+```
+
+Or through npm:
+
+```powershell
+npm run gear-sync:install-task
+```
+
+By default the task opens:
+
+```text
+https://armory.warmane.com/character/Lausudo/Lordaeron/summary
+```
+
+To use a different Warmane character page:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1 -TargetUrl "https://armory.warmane.com/character/CharacterName/Lordaeron/summary"
+```
+
+To use the Windows default browser instead of auto-detecting Chrome or Edge:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1 -UseDefaultBrowser
+```
+
+## Run Or Inspect
+
+```powershell
+Start-ScheduledTask -TaskName PizzaLogsGearSync
+Get-ScheduledTask -TaskName PizzaLogsGearSync
+Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd"
+Get-Content .\.sync-agent-logs\gear-sync-launcher.log -Tail 20
+```
+
+## Uninstall
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\uninstall-windows-task.ps1
+```
+
+Or through npm:
+
+```powershell
+npm run gear-sync:uninstall-task
+```
+
+## Limits
+
+- This is browser-assisted automation, not a Railway-side worker.
+- It cannot run before the Windows user logs in, because the browser and
+  Tampermonkey need an interactive user profile.
+- If the PC is asleep or offline, the Startup folder launcher catches the next
+  restart or login, and the hourly task resumes after Windows is active.
+- If the browser opens many Warmane tabs, close old ones periodically or change
+  the target browser/profile setup.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "db:generate": "prisma generate",
     "type-check": "tsc --noEmit",
     "db:seed-items": "ts-node --project tsconfig.seed.json scripts/seed-wow-items.ts",
-    "db:import-items": "ts-node --project tsconfig.seed.json scripts/import-item-template.ts"
+    "db:import-items": "ts-node --project tsconfig.seed.json scripts/import-item-template.ts",
+    "gear-sync:install-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/install-windows-task.ps1",
+    "gear-sync:uninstall-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/uninstall-windows-task.ps1"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/scripts/gear-sync/install-windows-task.ps1
+++ b/scripts/gear-sync/install-windows-task.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [string]$TaskName = "PizzaLogsGearSync",
+  [string]$TargetUrl = "https://armory.warmane.com/character/Lausudo/Lordaeron/summary",
+  [int]$IntervalMinutes = 60,
+  [int]$StartDelayMinutes = 5,
+  [string]$BrowserPath = "",
+  [switch]$UseDefaultBrowser,
+  [switch]$RunNow
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($IntervalMinutes -lt 15) {
+  throw "IntervalMinutes must be at least 15."
+}
+
+$launcherPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "open-warmane-gear-sync.ps1")).Path
+$startAt = (Get-Date).AddMinutes($StartDelayMinutes).ToString("HH:mm")
+$startupFolder = [Environment]::GetFolderPath("Startup")
+$startupCommandPath = Join-Path $startupFolder "PizzaLogsGearSyncAtLogon.cmd"
+
+$taskArguments = @(
+  "-NoProfile",
+  "-ExecutionPolicy",
+  "Bypass",
+  "-File",
+  "`"$launcherPath`"",
+  "-TargetUrl",
+  "`"$TargetUrl`""
+)
+
+if (-not [string]::IsNullOrWhiteSpace($BrowserPath)) {
+  $taskArguments += @("-BrowserPath", "`"$BrowserPath`"")
+}
+
+if ($UseDefaultBrowser) {
+  $taskArguments += "-UseDefaultBrowser"
+}
+
+$taskCommand = "powershell.exe $($taskArguments -join ' ')"
+$schtasks = "schtasks.exe"
+
+function Invoke-Schtasks {
+  param([string[]]$Arguments)
+
+  & $schtasks @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "schtasks.exe failed with exit code $LASTEXITCODE."
+  }
+}
+
+if ($PSCmdlet.ShouldProcess($TaskName, "Register hourly Pizza Logs Gear Sync scheduled task")) {
+  Invoke-Schtasks @(
+    "/Create",
+    "/TN", $TaskName,
+    "/SC", "MINUTE",
+    "/MO", "$IntervalMinutes",
+    "/ST", $startAt,
+    "/TR", $taskCommand,
+    "/F"
+  )
+
+  Set-Content -LiteralPath $startupCommandPath -Value @(
+    "@echo off",
+    $taskCommand
+  ) -Encoding ascii
+
+  if ($RunNow) {
+    Invoke-Schtasks @("/Run", "/TN", $TaskName)
+  }
+
+  Write-Host "Registered scheduled task '$TaskName'."
+  Write-Host "Created startup launcher '$startupCommandPath'."
+  Write-Host "Target URL: $TargetUrl"
+  Write-Host "Interval: every $IntervalMinutes minutes, plus at logon."
+}

--- a/scripts/gear-sync/open-warmane-gear-sync.ps1
+++ b/scripts/gear-sync/open-warmane-gear-sync.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+  [string]$TargetUrl = "https://armory.warmane.com/character/Lausudo/Lordaeron/summary",
+  [string]$BrowserPath = "",
+  [switch]$UseDefaultBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
+$logDir = Join-Path $repoRoot ".sync-agent-logs"
+$logFile = Join-Path $logDir "gear-sync-launcher.log"
+
+function Write-GearSyncLog {
+  param([string]$Message)
+  if (-not (Test-Path -LiteralPath $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+  }
+  $stamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+  Add-Content -LiteralPath $logFile -Value "[$stamp] $Message"
+}
+
+function Add-BrowserCandidate {
+  param(
+    [System.Collections.Generic.List[string]]$Candidates,
+    [string]$BasePath,
+    [string]$RelativePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($BasePath)) {
+    return
+  }
+
+  $Candidates.Add((Join-Path $BasePath $RelativePath))
+}
+
+function Resolve-BrowserPath {
+  if (-not [string]::IsNullOrWhiteSpace($BrowserPath)) {
+    if (-not (Test-Path -LiteralPath $BrowserPath)) {
+      throw "BrowserPath does not exist: $BrowserPath"
+    }
+    return (Resolve-Path -LiteralPath $BrowserPath).Path
+  }
+
+  if ($UseDefaultBrowser) {
+    return $null
+  }
+
+  $candidates = [System.Collections.Generic.List[string]]::new()
+  Add-BrowserCandidate $candidates $env:LOCALAPPDATA "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates $env:ProgramFiles "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates $env:ProgramFiles "Microsoft\Edge\Application\msedge.exe"
+  Add-BrowserCandidate $candidates ${env:ProgramFiles(x86)} "Microsoft\Edge\Application\msedge.exe"
+  Add-BrowserCandidate $candidates $env:LOCALAPPDATA "Microsoft\Edge\Application\msedge.exe"
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+
+  return $null
+}
+
+try {
+  if ($TargetUrl -notmatch "^https://armory\.warmane\.com/character/[^/]+/[^/]+/(summary|profile)([/?#].*)?$") {
+    throw "TargetUrl must be a Warmane character summary or profile URL."
+  }
+
+  $browser = Resolve-BrowserPath
+
+  if ($null -eq $browser) {
+    Write-GearSyncLog "Opening $TargetUrl with the Windows default browser. Warmane Gear Sync userscript must be installed in that browser."
+    Start-Process -FilePath $TargetUrl
+  } else {
+    Write-GearSyncLog "Opening $TargetUrl with $browser. Warmane Gear Sync userscript must be installed in that browser."
+    Start-Process -FilePath $browser -ArgumentList @($TargetUrl)
+  }
+} catch {
+  Write-GearSyncLog "Launch failed: $($_.Exception.Message)"
+  throw
+}

--- a/scripts/gear-sync/uninstall-windows-task.ps1
+++ b/scripts/gear-sync/uninstall-windows-task.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [string]$TaskName = "PizzaLogsGearSync"
+)
+
+$ErrorActionPreference = "Stop"
+
+$schtasks = "schtasks.exe"
+$startupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGearSyncAtLogon.cmd"
+$removed = 0
+$found = 0
+
+& $schtasks /Query /TN $TaskName *> $null
+if ($LASTEXITCODE -eq 0) {
+  $found++
+  if ($PSCmdlet.ShouldProcess($TaskName, "Delete Pizza Logs Gear Sync scheduled task")) {
+    & $schtasks /Delete /TN $TaskName /F
+    if ($LASTEXITCODE -ne 0) {
+      throw "schtasks.exe delete failed with exit code $LASTEXITCODE."
+    }
+    $removed++
+  }
+}
+
+if (Test-Path -LiteralPath $startupCommandPath) {
+  $found++
+  if ($PSCmdlet.ShouldProcess($startupCommandPath, "Remove Pizza Logs Gear Sync startup launcher")) {
+    Remove-Item -LiteralPath $startupCommandPath -Force
+    Write-Host "Removed startup launcher '$startupCommandPath'."
+    $removed++
+  }
+}
+
+if ($found -eq 0) {
+  Write-Host "No scheduled task named '$TaskName' or startup launcher '$startupCommandPath' exists."
+}

--- a/tests/gear-sync-windows-task-source.test.ts
+++ b/tests/gear-sync-windows-task-source.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import pkg from "../package.json";
+
+const root = process.cwd();
+const packageScripts = pkg.scripts as Record<string, string>;
+const launcher = readFileSync(path.join(root, "scripts", "gear-sync", "open-warmane-gear-sync.ps1"), "utf8");
+const installer = readFileSync(path.join(root, "scripts", "gear-sync", "install-windows-task.ps1"), "utf8");
+const uninstaller = readFileSync(path.join(root, "scripts", "gear-sync", "uninstall-windows-task.ps1"), "utf8");
+const docs = readFileSync(path.join(root, "docs", "gear-sync-windows-task.md"), "utf8");
+
+assert.match(launcher, /https:\/\/armory\.warmane\.com\/character\/Lausudo\/Lordaeron\/summary/);
+assert.match(launcher, /\.sync-agent-logs/);
+assert.match(launcher, /chrome\.exe/i);
+assert.match(launcher, /msedge\.exe/i);
+assert.match(launcher, /Warmane Gear Sync userscript/i);
+
+assert.match(installer, /PizzaLogsGearSync/);
+assert.match(installer, /schtasks\.exe/i);
+assert.match(installer, /\/SC"\s*,\s*"MINUTE"/);
+assert.match(installer, /GetFolderPath\("Startup"\)/);
+assert.match(installer, /PizzaLogsGearSyncAtLogon\.cmd/);
+assert.match(installer, /open-warmane-gear-sync\.ps1/);
+assert.doesNotMatch(installer, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
+
+assert.match(uninstaller, /schtasks\.exe/i);
+assert.match(uninstaller, /\/Delete/);
+assert.match(uninstaller, /PizzaLogsGearSync/);
+assert.match(uninstaller, /PizzaLogsGearSyncAtLogon\.cmd/);
+assert.doesNotMatch(uninstaller, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
+
+assert.match(docs, /does not store the Pizza Logs admin secret/i);
+assert.match(docs, /Tampermonkey/i);
+assert.match(docs, /persists through restarts/i);
+assert.match(docs, /Startup folder/i);
+assert.match(docs, /\.sync-agent-logs/);
+
+assert.equal(
+  packageScripts["gear-sync:install-task"],
+  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/install-windows-task.ps1",
+);
+assert.equal(
+  packageScripts["gear-sync:uninstall-task"],
+  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/uninstall-windows-task.ps1",
+);
+
+console.log("gear-sync-windows-task-source tests passed");


### PR DESCRIPTION
## Summary
- Add Windows Gear Sync automation scripts that open a Warmane character page hourly through Task Scheduler and at logon through the Startup folder.
- Add npm install/uninstall shortcuts plus docs for setup, logs, limits, and removal.
- Update README/vault notes and add a source test proving the task files do not store production secrets.

## Validation
- Local Warmane API probe from PowerShell returned HTTP 403, confirming browser-assisted automation is still needed.
- node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1 -WhatIf
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\uninstall-windows-task.ps1 -WhatIf
- node node_modules\typescript\bin\tsc --noEmit
- node node_modules\eslint\bin\eslint.js . --max-warnings=0
- npm run build

## Local install performed
- Registered current-user hourly task: PizzaLogsGearSync
- Created Startup launcher: C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd
- No admin secret or DB/Railway secret is stored in the task or launcher.

## Deployment notes
- No Prisma migration or environment variable changes.
- After merge/deploy, make sure the production Gear Sync userscript is installed/updated and its admin secret is saved once on Warmane.