### PR TITLE
Automate guild roster sync on Windows

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -25,8 +25,8 @@
   clutter the DPS/HPS by encounter trend.
 - Gear Sync now refreshes every known Pizza Logs character from Warmane once per
   hour, instead of only importing players with missing or incomplete cached gear.
-- Local Windows automation can now open a Warmane character page hourly and at
-  logon so the browser Gear Sync userscript can run after restarts.
+- Local Windows automation can now open Warmane character and guild roster pages
+  hourly and at logon so the browser userscripts can run after restarts.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -53,9 +53,13 @@
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
-- Gear userscript v1.8.0 requests the full refresh queue hourly; roster userscript v1.0.5 stores admin secrets per Pizza Logs target origin and shows the target in the Warmane panel, so local and production secrets no longer overwrite each other on `armory.warmane.com`.
+- Gear userscript v1.8.0 requests the full refresh queue hourly; roster
+  userscript v1.1.0 stores admin secrets per Pizza Logs target origin, shows the
+  target in the Warmane panel, and auto-runs hourly after a secret is saved.
 - Windows gear automation scripts live under `scripts/gear-sync/`; docs live in
   `docs/gear-sync-windows-task.md`.
+- Windows guild roster automation scripts live under `scripts/guild-roster-sync/`;
+  docs live in `docs/guild-roster-sync-windows-task.md`.
 - The cinematic intro now uses generated video assets from `animations/source/Veo.mp4` instead of the retired `public/intro` asset set.
 
 ## Tampermonkey Auth Session
@@ -108,6 +112,29 @@
 - Installed the current-user hourly scheduled task on Neil's Windows machine.
 - Created the Startup-folder launcher at
   `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd`.
+
+## Windows Guild Roster Sync Task Session
+
+- Extended the roster userscript so saved-secret Warmane guild page visits
+  auto-sync at most once per hour.
+- Bumped Guild Roster Sync to `1.1.0`.
+- Added `scripts/guild-roster-sync/open-warmane-guild-roster-sync.ps1` to open
+  the Pizza Warriors Warmane guild summary page through Chrome, Edge, or the
+  Windows default browser.
+- Added `scripts/guild-roster-sync/install-windows-task.ps1` to register the
+  hourly `PizzaLogsGuildRosterSync` task through `schtasks.exe` and create a
+  Startup-folder `PizzaLogsGuildRosterSyncAtLogon.cmd` launcher.
+- Added `scripts/guild-roster-sync/uninstall-windows-task.ps1` for cleanup.
+- Added npm shortcuts:
+  - `npm run guild-roster-sync:install-task`
+  - `npm run guild-roster-sync:uninstall-task`
+- Added `docs/guild-roster-sync-windows-task.md` with setup, limits, logs,
+  Startup folder behavior, and uninstall instructions.
+- Hardened both gear and roster uninstall scripts so missing tasks/startup
+  launchers are clean no-ops.
+- Installed the current-user hourly scheduled task on Neil's Windows machine.
+- Created the Startup-folder launcher at
+  `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.cmd`.
 
 ## Cinematic Intro Session
 
@@ -209,6 +236,17 @@
 | `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1` | Passed; registered `PizzaLogsGearSync` and created Startup launcher |
 | `schtasks.exe /Query /TN PizzaLogsGearSync /FO LIST /V` | Passed; task is ready and repeats every 1 hour |
 | Startup launcher content check | Passed; points at `scripts\gear-sync\open-warmane-gear-sync.ps1` |
+| `npx ts-node --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed |
+| `npx ts-node --project tsconfig.seed.json tests\guild-roster-sync-windows-task-source.test.ts` | Passed |
+| `npx ts-node --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts` | Passed |
+| `npx ts-node --project tsconfig.seed.json tests\local-userscript-routes.test.ts` | Passed |
+| JSX-aware `tests\guild-roster-admin-panel.test.ts` | Passed |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1 -WhatIf` | Passed |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\uninstall-windows-task.ps1 -WhatIf` | Passed; missing task/startup launcher is a clean no-op |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\uninstall-windows-task.ps1 -WhatIf` | Passed |
+| `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1` | Passed; registered `PizzaLogsGuildRosterSync` and created Startup launcher |
+| `schtasks.exe /Query /TN PizzaLogsGuildRosterSync /FO LIST /V` | Passed; task is ready and repeats every 1 hour |
+| Guild roster startup launcher content check | Passed; points at `scripts\guild-roster-sync\open-warmane-guild-roster-sync.ps1` |
 | Local `GET http://127.0.0.1:3001/guild-roster?page=2` | Passed with HTTP 200 after dev server compile |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed |
@@ -246,16 +284,17 @@
 - `pull_request_target` runs the Slack workflow from `main`, so Slack formatting changes only affect fresh PR events after the workflow update is merged.
 - Absorbs remain future parser work.
 - Railway CLI is installed locally but this checkout remains unlinked until Neil intentionally runs `railway link`.
-- Hourly full gear refresh depends on a local Windows user/browser profile with
-  the production Gear Sync userscript installed and the correct admin secret saved.
+- Hourly full gear and roster refreshes depend on a local Windows user/browser
+  profile with the production userscripts installed and the correct admin secret
+  saved.
 - The current-user task is interactive only. It persists through restarts, but it
   cannot run before Neil logs into Windows.
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR for the local Windows Gear Sync automation.
-After deployment, reinstall/update the production Gear Sync userscript from
-`/admin`, open any Warmane character page, and click `Sync now` once if the
-admin secret is not already saved. The scheduled task can then keep opening
-Warmane hourly after restarts. Neil merges into `main` only after review; Codex
-does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR for the local Windows roster automation.
+After deployment, reinstall/update the production Guild Roster Sync userscript
+from `/admin`, open the Warmane Pizza Warriors guild summary page, and click
+`Sync roster` once if the admin secret is not already saved. The scheduled task
+can then keep opening Warmane hourly after restarts. Neil merges into `main`
+only after review; Codex does not merge or push `main` directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session added local Windows automation for Gear Sync. Direct local CLI requests to Warmane still return 403, so the automation opens a real Warmane character page hourly and at Windows logon; the browser Gear Sync userscript handles the actual refresh. Parser reliability remains the highest-risk product area.
+The current session added local Windows automation for Guild Roster Sync, matching the Gear Sync setup. Direct local CLI requests to Warmane still return 403, so the automation opens real Warmane pages hourly and at Windows logon; the browser userscripts handle the actual refreshes. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -14,6 +14,16 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Extended the Guild Roster Sync userscript so saved-secret Warmane guild page visits auto-sync at most once per hour.
+- Bumped Guild Roster Sync to `1.1.0`.
+- Added Windows guild roster automation scripts under `scripts/guild-roster-sync/`.
+- Added `npm run guild-roster-sync:install-task` and `npm run guild-roster-sync:uninstall-task`.
+- Added `docs/guild-roster-sync-windows-task.md`.
+- Added `tests/guild-roster-sync-windows-task-source.test.ts` and expanded roster userscript/admin/local route coverage.
+- Hardened both gear and roster uninstall scripts so missing scheduled tasks/startup launchers are clean no-ops.
+- Installed the actual `PizzaLogsGuildRosterSync` hourly task on Neil's Windows machine.
+- Created `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.cmd`.
+- Queried the scheduled task and startup launcher; both point at `scripts\guild-roster-sync\open-warmane-guild-roster-sync.ps1`.
 - Investigated the Gear Sync status `No players need import or enrichment.` after Neil clarified that existing DB players should be updated to their current Warmane gear.
 - Confirmed the existing queue only returned missing or enrichment-needed cached gear rows.
 - Added a refresh-all queue helper that returns all known combat-log players plus PizzaWarriors/Lordaeron roster members, de-duped by character and realm.
@@ -135,6 +145,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
 | Hourly Gear Sync refresh-all | DONE | Gear `1.8.0` refreshes all known DB/roster characters hourly from Warmane |
 | Windows Gear Sync scheduled task | DONE | Task Scheduler opens a Warmane character page hourly; Startup folder opens it at logon |
+| Windows Guild Roster Sync scheduled task | DONE | Task Scheduler opens the Warmane guild roster page hourly; Startup folder opens it at logon |
 | ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
 | Session player chart kill filter | DONE | DPS/HPS by encounter chart excludes wipes; Encounter Breakdown still lists all pulls |
 
@@ -146,6 +157,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
 - Use `scripts/gear-sync/install-windows-task.ps1` or `npm run gear-sync:install-task` to keep Gear Sync running hourly from Windows.
 - After the Windows automation PR deploys, reinstall/update the production Gear Sync userscript from `/admin`; open any Warmane character page and click `Sync now` once if the admin secret is not saved.
+- After the roster automation PR deploys, reinstall/update the production Guild Roster Sync userscript from `/admin`; open the Warmane Pizza Warriors guild page and click `Sync roster` once if the admin secret is not saved.
 - After this parser fix deploys, reprocess or re-upload the affected latest raid so stored Saurfang and Valithria difficulties are regenerated.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.

--- a/Pizza Logs HQ/05 Features/Feature Status.md
+++ b/Pizza Logs HQ/05 Features/Feature Status.md
@@ -15,13 +15,14 @@ This file is the single source for shipped features, active backlog, and technic
 | Admin auth | `/admin` and admin APIs require `ADMIN_SECRET`; production fails closed if missing |
 | Admin diagnostics | Service health, DB counts, upload timings, upload history, cleanup controls |
 | Public upload telemetry removal | Upload history/detail moved behind admin; `/uploads` redirects to admin |
-| Guild roster | Cached PizzaWarriors/Lordaeron roster rows with rank/profession parsing |
+| Guild roster | Cached PizzaWarriors/Lordaeron roster rows with rank/profession parsing and hourly browser-assisted refresh |
 | Roster-only profiles | `/players/<name>` resolves roster members without combat-log rows |
 | Header search | Searches combat-log players plus roster-only members through `/api/players/search` |
 | Gear cache | Warmane snapshots cached in `armory_gear_cache`, with GearScoreLite display |
 | Item metadata | AzerothCore `item_template` import populates `wow_items`; no runtime Wowhead API dependency |
 | Gear/userscript import | Browser-assisted Warmane Gear Sync refreshes known character gear hourly and fills icon gaps |
-| Windows gear sync task | Task Scheduler opens Warmane hourly and Startup folder opens it at logon so Gear Sync can run after restarts |
+| Roster/userscript import | Browser-assisted Warmane Guild Roster Sync refreshes roster rows hourly after a secret is saved |
+| Windows Warmane sync tasks | Task Scheduler opens Warmane character and guild roster pages hourly, and Startup folder opens them at logon so userscripts can run after restarts |
 | Class-icon avatars | Player avatars use WoW class icons with initials fallback |
 | ICC ordering | Shared helpers keep ICC boss displays in progression order where appropriate |
 | Local test server helpers | Windows scripts start/stop web and parser test servers |
@@ -32,7 +33,7 @@ This file is the single source for shipped features, active backlog, and technic
 
 | Item | Status |
 |---|---|
-| Warmane production data freshness | Browser-assisted Windows Task Scheduler automation is available; fully headless sync remains future work |
+| Warmane production data freshness | Browser-assisted Windows Task Scheduler automation is available for gear and roster; fully headless sync remains future work |
 | Absorbs | Future parser work; not currently implemented |
 
 ## Backlog
@@ -42,7 +43,7 @@ This file is the single source for shipped features, active backlog, and technic
 | High | Absorbs tracking | Implement Skada `Absorbs.lua` style separate absorb metric, not healing |
 | High | Server-side upload size enforcement | Enforce a hard byte limit while streaming to parser |
 | Medium | Upload rate limiting | Prefer Railway-level controls first, app-level only if needed |
-| Medium | Local automated Warmane sync agent | Replace manual roster/gear userscript runs with low-risk local automation |
+| Medium | Fully headless local Warmane sync agent | Replace browser-assisted roster/gear userscript runs if Warmane access allows it |
 | Medium | Damage mitigation stats | Track `SPELL_MISSED` subtypes such as ABSORB, BLOCK, PARRY, DODGE |
 | Medium | Consumable tracking | Known buff applications |
 | Low | Fastest kill records | Per boss/difficulty shortest duration kills |
@@ -54,7 +55,7 @@ This file is the single source for shipped features, active backlog, and technic
 
 | Debt | Impact | Fix |
 |---|---|---|
-| Browser-dependent Warmane sync | Gear refresh depends on a logged-in Windows browser profile | Future fully headless local sync agent if Warmane access allows it |
+| Browser-dependent Warmane sync | Gear and roster refreshes depend on a logged-in Windows browser profile | Future fully headless local sync agent if Warmane access allows it |
 | Upload lacks hard size cap | Large uploads can waste resources | Enforce size during upload/forwarding |
 | Role inference is rough | Hybrids and tanks can be mislabeled | Use better class/spec/combat evidence |
 | Encounter detail links to global player profile | Different navigation from session pages | Pass upload/session context where needed |

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -12,7 +12,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Upload rate limiting is not implemented | Abuse could create parser/DB load | Prefer Railway-level controls first; add app logic only if needed |
 | Absorbs are not implemented | Disc priest contribution can be lower than Skada combined healing+absorbs views | Future parser work based on Skada `Absorbs.lua`; keep separate from healing done |
 | Role detection is rough | Hybrids/self-healing classes can be mislabeled; tanks are not inferred | Replace upload-time heal/damage ratio with better class/spec/combat evidence |
-| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway or plain CLI requests | Supported path is browser-assisted userscripts, Windows Task Scheduler launch, and cached DB snapshots |
+| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway or plain CLI requests | Supported path is browser-assisted userscripts, Windows Task Scheduler launches for gear and roster, and cached DB snapshots |
 | Some heroic/Gunship difficulty evidence is absent | Certain pulls cannot be classified perfectly from logs alone | Use direct marker evidence first; keep normal-looking non-Gunship fallback attempts normal; document uncertainty |
 | Orphaned pets can remain unmatched | Small DPS mismatches when pets were active before log start | Keep Skada-aligned owner remap when summon evidence exists |
 
@@ -53,6 +53,8 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Local and production Warmane userscripts shared the same saved admin secret | Gear `1.7.1` and roster `1.0.5` now use target-specific localStorage keys, show the target host, and clear the legacy shared key on unauthorized responses |
 | Gear Sync skipped already cached characters | Gear `1.8.0` requests refresh-all mode hourly so complete cached players are refreshed from Warmane too |
 | Gear Sync only ran when Neil manually visited Warmane | Added Windows automation that opens a Warmane character page hourly through Task Scheduler and at logon through the Startup folder |
+| Guild Roster Sync only ran when Neil manually visited Warmane | Roster `1.1.0` auto-runs hourly with a saved target secret, and Windows automation opens the Warmane guild roster page hourly through Task Scheduler and at logon through the Startup folder |
+| Windows sync uninstall scripts errored when no task existed | Gear and roster uninstall scripts now treat missing scheduled tasks/startup launchers as clean no-ops |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ Player profiles merge:
 Warmane live server fetches are best-effort and may fail from Railway or local scripts because of Cloudflare/403 behavior. The supported operational path is browser-assisted import from `/admin`:
 
 - Warmane Gear Sync userscript for hourly current-equipment refreshes and icon backfill.
-- Warmane Guild Roster userscript for roster rank, class, race, professions, and member rows.
+- Warmane Guild Roster userscript for hourly roster rank, class, race, professions, and member refreshes.
 
 For Windows persistence, the repo includes a Task Scheduler setup that opens a
 Warmane character page hourly so the Gear Sync userscript can run after restarts:
 [`docs/gear-sync-windows-task.md`](docs/gear-sync-windows-task.md).
+The guild roster has the same local Windows automation:
+[`docs/guild-roster-sync-windows-task.md`](docs/guild-roster-sync-windows-task.md).
 
 Player avatars intentionally use class icons instead of Warmane-rendered character portraits. The old portrait userscript URL remains only as a no-op compatibility update for existing installs.
 

--- a/app/admin/GuildRosterSyncPanel.tsx
+++ b/app/admin/GuildRosterSyncPanel.tsx
@@ -29,9 +29,10 @@ export function GuildRosterSyncPanel({
       <p className="text-sm text-text-secondary max-w-3xl">
         Warmane blocks server-side requests from Railway, so the roster is synced via a
         browser userscript. Install the userscript below, open the Warmane guild page, and
-        click the floating Pizza Logs Roster Sync button. Your browser fetches the roster
-        and posts it to Pizza Logs. The public roster page reads only from our database, so
-        it loads even when Warmane is unavailable.
+        click the floating Pizza Logs Roster Sync button once to save the admin secret.
+        After that, opening the guild page can auto-sync the roster hourly. The public
+        roster page reads only from our database, so it loads even when Warmane is
+        unavailable.
       </p>
 
       <div className="flex flex-wrap items-center gap-4">
@@ -45,7 +46,8 @@ export function GuildRosterSyncPanel({
           <h3 className="heading-cinzel text-sm text-gold tracking-wide">Browser Roster Import</h3>
           <p className="text-sm text-text-secondary mt-1">
             Install this userscript with Tampermonkey, then open the Warmane guild page below.
-            The floating Pizza Logs Roster Sync button will import the full roster into Pizza Logs.
+            The floating Pizza Logs Roster Sync button will import the full roster into Pizza Logs,
+            and saved-secret visits can auto-sync the roster hourly.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">

--- a/docs/guild-roster-sync-windows-task.md
+++ b/docs/guild-roster-sync-windows-task.md
@@ -1,0 +1,86 @@
+# Windows Guild Roster Sync Automation
+
+Pizza Logs can refresh the PizzaWarriors/Lordaeron roster from Neil's Windows
+PC without putting anything on Railway. Warmane blocks plain server-side and CLI
+requests with 403, so this automation opens the real Warmane guild page and
+lets the Tampermonkey Guild Roster Sync userscript do the import from the
+browser.
+
+This setup persists through restarts by combining one hourly Task Scheduler task
+with one Startup folder launcher. Both run when the Windows user is logged in.
+
+## What It Does
+
+- Opens the Warmane Pizza Warriors guild page once per hour.
+- Opens the same page at Windows logon from the Startup folder.
+- Relies on the installed Pizza Logs Guild Roster Sync userscript to import the
+  full roster.
+- Writes launcher logs to `.sync-agent-logs/guild-roster-sync-launcher.log`.
+
+The scheduled task does not store the Pizza Logs admin secret, `DATABASE_URL`,
+Railway tokens, or other production secrets. The admin secret remains wherever
+the browser userscript stores it for `armory.warmane.com`.
+
+## Prerequisites
+
+1. Install or update the production Guild Roster Sync userscript from `/admin`.
+2. Open the Warmane guild page.
+3. Click `Sync roster` once and enter the production admin secret.
+4. Confirm Roster Sync shows the production target.
+
+## Install The Task
+
+From the repo root:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1
+```
+
+Or through npm:
+
+```powershell
+npm run guild-roster-sync:install-task
+```
+
+By default the task opens:
+
+```text
+https://armory.warmane.com/guild/Pizza+Warriors/Lordaeron/summary
+```
+
+To use the Windows default browser instead of auto-detecting Chrome or Edge:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1 -UseDefaultBrowser
+```
+
+## Run Or Inspect
+
+```powershell
+Start-ScheduledTask -TaskName PizzaLogsGuildRosterSync
+Get-ScheduledTask -TaskName PizzaLogsGuildRosterSync
+Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.cmd"
+Get-Content .\.sync-agent-logs\guild-roster-sync-launcher.log -Tail 20
+```
+
+## Uninstall
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\uninstall-windows-task.ps1
+```
+
+Or through npm:
+
+```powershell
+npm run guild-roster-sync:uninstall-task
+```
+
+## Limits
+
+- This is browser-assisted automation, not a Railway-side worker.
+- It cannot run before the Windows user logs in, because the browser and
+  Tampermonkey need an interactive user profile.
+- If the PC is asleep or offline, the Startup folder launcher catches the next
+  restart or login, and the hourly task resumes after Windows is active.
+- The roster userscript must have the correct production admin secret saved once
+  before automatic runs can post to Pizza Logs.

--- a/lib/guild-roster-client-scripts.ts
+++ b/lib/guild-roster-client-scripts.ts
@@ -24,6 +24,8 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
     const realm = "__WARMANE_REALM__";
     const legacySecretKey = "pizzaLogsAdminSecret";
     const secretKey = "pizzaLogsAdminSecret:__PIZZA_LOGS_ORIGIN__";
+    const lastRunKey = "pizzaLogsLastRosterSyncAt:__PIZZA_LOGS_ORIGIN__";
+    const autoIntervalMs = 60 * 60 * 1000;
 
     if (location.hostname !== "armory.warmane.com") {
       alert("Pizza Logs: open Warmane Armory first, then run the roster importer.");
@@ -114,6 +116,7 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
           realm,
           ...payload,
         });
+        localStorage.setItem(lastRunKey, String(Date.now()));
         setStatus(`Imported ${result.count} roster ${result.count === 1 ? "member" : "members"}.`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -186,6 +189,7 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
       reset.addEventListener("click", () => {
         localStorage.removeItem(secretKey);
         localStorage.removeItem(legacySecretKey);
+        localStorage.removeItem(lastRunKey);
         setStatus("Secret cleared. Click Sync roster to enter it again.");
       });
 
@@ -201,6 +205,16 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
     const autoRunFlag: string = "__AUTO_RUN__";
     if (autoRunFlag === "true") {
       setTimeout(runRosterSync, 500);
+    } else {
+      const lastRun = Number(localStorage.getItem(lastRunKey) || "0");
+      const hasSecret = Boolean(localStorage.getItem(secretKey));
+      if (hasSecret && Date.now() - lastRun > autoIntervalMs) {
+        setTimeout(runRosterSync, 2500);
+      } else if (!hasSecret) {
+        setStatus("Click Sync roster once to save the admin secret and enable auto-sync.");
+      } else {
+        setStatus("Roster auto-sync armed. Click Sync roster to force a refresh.");
+      }
     }
   };
 
@@ -229,8 +243,8 @@ export function buildGuildRosterUserscript(options: GuildRosterUserscriptOptions
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Guild Roster Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.0.5",
-    "// @description  Sync Pizza Logs guild roster from Warmane Armory in-browser.",
+    "// @version      1.1.0",
+    "// @description  Hourly sync Pizza Logs guild roster from Warmane Armory in-browser.",
     "// @match        https://armory.warmane.com/guild/*",
     "// @match        http://armory.warmane.com/guild/*",
     `// @downloadURL   ${userscriptUrl}`,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "db:seed-items": "ts-node --project tsconfig.seed.json scripts/seed-wow-items.ts",
     "db:import-items": "ts-node --project tsconfig.seed.json scripts/import-item-template.ts",
     "gear-sync:install-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/install-windows-task.ps1",
-    "gear-sync:uninstall-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/uninstall-windows-task.ps1"
+    "gear-sync:uninstall-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/gear-sync/uninstall-windows-task.ps1",
+    "guild-roster-sync:install-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guild-roster-sync/install-windows-task.ps1",
+    "guild-roster-sync:uninstall-task": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guild-roster-sync/uninstall-windows-task.ps1"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/scripts/guild-roster-sync/install-windows-task.ps1
+++ b/scripts/guild-roster-sync/install-windows-task.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [string]$TaskName = "PizzaLogsGuildRosterSync",
+  [string]$TargetUrl = "https://armory.warmane.com/guild/Pizza+Warriors/Lordaeron/summary",
+  [int]$IntervalMinutes = 60,
+  [int]$StartDelayMinutes = 8,
+  [string]$BrowserPath = "",
+  [switch]$UseDefaultBrowser,
+  [switch]$RunNow
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($IntervalMinutes -lt 15) {
+  throw "IntervalMinutes must be at least 15."
+}
+
+$launcherPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "open-warmane-guild-roster-sync.ps1")).Path
+$startAt = (Get-Date).AddMinutes($StartDelayMinutes).ToString("HH:mm")
+$startupFolder = [Environment]::GetFolderPath("Startup")
+$startupCommandPath = Join-Path $startupFolder "PizzaLogsGuildRosterSyncAtLogon.cmd"
+
+$taskArguments = @(
+  "-NoProfile",
+  "-ExecutionPolicy",
+  "Bypass",
+  "-File",
+  "`"$launcherPath`"",
+  "-TargetUrl",
+  "`"$TargetUrl`""
+)
+
+if (-not [string]::IsNullOrWhiteSpace($BrowserPath)) {
+  $taskArguments += @("-BrowserPath", "`"$BrowserPath`"")
+}
+
+if ($UseDefaultBrowser) {
+  $taskArguments += "-UseDefaultBrowser"
+}
+
+$taskCommand = "powershell.exe $($taskArguments -join ' ')"
+$schtasks = "schtasks.exe"
+
+function Invoke-Schtasks {
+  param([string[]]$Arguments)
+
+  & $schtasks @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "schtasks.exe failed with exit code $LASTEXITCODE."
+  }
+}
+
+if ($PSCmdlet.ShouldProcess($TaskName, "Register hourly Pizza Logs Guild Roster Sync scheduled task")) {
+  Invoke-Schtasks @(
+    "/Create",
+    "/TN", $TaskName,
+    "/SC", "MINUTE",
+    "/MO", "$IntervalMinutes",
+    "/ST", $startAt,
+    "/TR", $taskCommand,
+    "/F"
+  )
+
+  Set-Content -LiteralPath $startupCommandPath -Value @(
+    "@echo off",
+    $taskCommand
+  ) -Encoding ascii
+
+  if ($RunNow) {
+    Invoke-Schtasks @("/Run", "/TN", $TaskName)
+  }
+
+  Write-Host "Registered scheduled task '$TaskName'."
+  Write-Host "Created startup launcher '$startupCommandPath'."
+  Write-Host "Target URL: $TargetUrl"
+  Write-Host "Interval: every $IntervalMinutes minutes, plus at logon."
+}

--- a/scripts/guild-roster-sync/open-warmane-guild-roster-sync.ps1
+++ b/scripts/guild-roster-sync/open-warmane-guild-roster-sync.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+  [string]$TargetUrl = "https://armory.warmane.com/guild/Pizza+Warriors/Lordaeron/summary",
+  [string]$BrowserPath = "",
+  [switch]$UseDefaultBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
+$logDir = Join-Path $repoRoot ".sync-agent-logs"
+$logFile = Join-Path $logDir "guild-roster-sync-launcher.log"
+
+function Write-GuildRosterSyncLog {
+  param([string]$Message)
+  if (-not (Test-Path -LiteralPath $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+  }
+  $stamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+  Add-Content -LiteralPath $logFile -Value "[$stamp] $Message"
+}
+
+function Add-BrowserCandidate {
+  param(
+    [System.Collections.Generic.List[string]]$Candidates,
+    [string]$BasePath,
+    [string]$RelativePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($BasePath)) {
+    return
+  }
+
+  $Candidates.Add((Join-Path $BasePath $RelativePath))
+}
+
+function Resolve-BrowserPath {
+  if (-not [string]::IsNullOrWhiteSpace($BrowserPath)) {
+    if (-not (Test-Path -LiteralPath $BrowserPath)) {
+      throw "BrowserPath does not exist: $BrowserPath"
+    }
+    return (Resolve-Path -LiteralPath $BrowserPath).Path
+  }
+
+  if ($UseDefaultBrowser) {
+    return $null
+  }
+
+  $candidates = [System.Collections.Generic.List[string]]::new()
+  Add-BrowserCandidate $candidates $env:LOCALAPPDATA "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates $env:ProgramFiles "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates ${env:ProgramFiles(x86)} "Google\Chrome\Application\chrome.exe"
+  Add-BrowserCandidate $candidates $env:ProgramFiles "Microsoft\Edge\Application\msedge.exe"
+  Add-BrowserCandidate $candidates ${env:ProgramFiles(x86)} "Microsoft\Edge\Application\msedge.exe"
+  Add-BrowserCandidate $candidates $env:LOCALAPPDATA "Microsoft\Edge\Application\msedge.exe"
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+
+  return $null
+}
+
+try {
+  if ($TargetUrl -notmatch "^https://armory\.warmane\.com/guild/[^/]+/[^/]+/summary([/?#].*)?$") {
+    throw "TargetUrl must be a Warmane guild summary URL."
+  }
+
+  $browser = Resolve-BrowserPath
+
+  if ($null -eq $browser) {
+    Write-GuildRosterSyncLog "Opening $TargetUrl with the Windows default browser. Warmane Guild Roster Sync userscript must be installed in that browser."
+    Start-Process -FilePath $TargetUrl
+  } else {
+    Write-GuildRosterSyncLog "Opening $TargetUrl with $browser. Warmane Guild Roster Sync userscript must be installed in that browser."
+    Start-Process -FilePath $browser -ArgumentList @($TargetUrl)
+  }
+} catch {
+  Write-GuildRosterSyncLog "Launch failed: $($_.Exception.Message)"
+  throw
+}

--- a/scripts/guild-roster-sync/uninstall-windows-task.ps1
+++ b/scripts/guild-roster-sync/uninstall-windows-task.ps1
@@ -1,12 +1,12 @@
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
-  [string]$TaskName = "PizzaLogsGearSync"
+  [string]$TaskName = "PizzaLogsGuildRosterSync"
 )
 
 $ErrorActionPreference = "Stop"
 
 $schtasks = "schtasks.exe"
-$startupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGearSyncAtLogon.cmd"
+$startupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGuildRosterSyncAtLogon.cmd"
 $removed = 0
 $found = 0
 
@@ -21,7 +21,7 @@ try {
 
 if ($queryExitCode -eq 0) {
   $found++
-  if ($PSCmdlet.ShouldProcess($TaskName, "Delete Pizza Logs Gear Sync scheduled task")) {
+  if ($PSCmdlet.ShouldProcess($TaskName, "Delete Pizza Logs Guild Roster Sync scheduled task")) {
     & $schtasks /Delete /TN $TaskName /F
     if ($LASTEXITCODE -ne 0) {
       throw "schtasks.exe delete failed with exit code $LASTEXITCODE."
@@ -32,7 +32,7 @@ if ($queryExitCode -eq 0) {
 
 if (Test-Path -LiteralPath $startupCommandPath) {
   $found++
-  if ($PSCmdlet.ShouldProcess($startupCommandPath, "Remove Pizza Logs Gear Sync startup launcher")) {
+  if ($PSCmdlet.ShouldProcess($startupCommandPath, "Remove Pizza Logs Guild Roster Sync startup launcher")) {
     Remove-Item -LiteralPath $startupCommandPath -Force
     Write-Host "Removed startup launcher '$startupCommandPath'."
     $removed++

--- a/tests/gear-sync-windows-task-source.test.ts
+++ b/tests/gear-sync-windows-task-source.test.ts
@@ -28,6 +28,8 @@ assert.match(uninstaller, /schtasks\.exe/i);
 assert.match(uninstaller, /\/Delete/);
 assert.match(uninstaller, /PizzaLogsGearSync/);
 assert.match(uninstaller, /PizzaLogsGearSyncAtLogon\.cmd/);
+assert.match(uninstaller, /queryExitCode/);
+assert.doesNotMatch(uninstaller, /\*>\s*\$null/);
 assert.doesNotMatch(uninstaller, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
 
 assert.match(docs, /does not store the Pizza Logs admin secret/i);

--- a/tests/guild-roster-admin-panel.test.ts
+++ b/tests/guild-roster-admin-panel.test.ts
@@ -15,6 +15,7 @@ assert.match(markup, /Roster Members/);
 assert.match(markup, /42/);
 assert.match(markup, /Warmane/);
 assert.match(markup, /Browser Roster Import/);
+assert.match(markup, /auto-sync the roster hourly/);
 assert.match(markup, /userscript\.user\.js/);
 assert.match(markup, /Install Local Roster Userscript/);
 assert.match(markup, new RegExp(LOCAL_GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/tests/guild-roster-client-scripts.test.ts
+++ b/tests/guild-roster-client-scripts.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import vm from "node:vm";
 import {
   LOCAL_GUILD_ROSTER_USERSCRIPT_URL,
   GUILD_ROSTER_USERSCRIPT_URL,
@@ -15,10 +16,12 @@ const localUserscript = buildGuildRosterUserscript({
 });
 assert.match(userscript, /Pizza Logs Warmane Guild Roster Sync/);
 assert.match(userscript, /api\/admin\/guild-roster\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.0\.5/);
+assert.match(userscript, /\/\/ @version\s+1\.1\.0/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/guild\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/guild\/\*/);
 assert.match(userscript, /pizzaLogsAdminSecret:https:\/\/pizza-logs-production\.up\.railway\.app/);
+assert.match(userscript, /pizzaLogsLastRosterSyncAt:https:\/\/pizza-logs-production\.up\.railway\.app/);
+assert.match(userscript, /autoIntervalMs = 60 \* 60 \* 1000/);
 assert.match(userscript, /isGuildPage/);
 assert.match(userscript, /api\/guild\/Pizza\+Warriors\/Lordaeron\/summary/);
 assert.match(userscript, /guild\/Pizza\+Warriors\/Lordaeron\/summary/);
@@ -42,4 +45,76 @@ assert.match(bookmarklet, /^javascript:/);
 assert.match(bookmarklet, /api\/admin\/guild-roster\/import/);
 assert.match(bookmarklet, /Pizza\+Warriors/);
 
-console.log("guild-roster-client-scripts tests passed");
+async function verifyUserscriptAutoRunsWithSavedSecret() {
+  const pending: Promise<unknown>[] = [];
+  const importBodies: Array<{ secret?: string; guild?: string; realm?: string; html?: string }> = [];
+  const storage = new Map<string, string>([
+    ["pizzaLogsAdminSecret:https://pizza-logs-production.up.railway.app", "secret"],
+    ["pizzaLogsLastRosterSyncAt:https://pizza-logs-production.up.railway.app", "0"],
+  ]);
+
+  const context = {
+    console: { warn() {} },
+    Date,
+    location: {
+      hostname: "armory.warmane.com",
+      pathname: "/guild/Pizza+Warriors/Lordaeron/summary",
+    },
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    },
+    prompt: () => {
+      throw new Error("Auto-sync should use the saved secret");
+    },
+    setTimeout: (callback: () => unknown) => {
+      const result = callback();
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        pending.push(result as Promise<unknown>);
+      }
+      return 1;
+    },
+    document: {
+      body: { appendChild() {} },
+      addEventListener() {},
+      createElement: () => ({
+        style: { cssText: "" },
+        append() {},
+        addEventListener() {},
+        textContent: "",
+        type: "",
+        disabled: false,
+      }),
+    },
+    fetch: async (url: string, init?: { body?: string }) => {
+      if (url === "/guild/Pizza+Warriors/Lordaeron/summary") {
+        return { ok: true, text: async () => "<html>roster</html>" };
+      }
+      if (url.endsWith("/api/admin/guild-roster/import")) {
+        importBodies.push(JSON.parse(init?.body ?? "{}"));
+        return { ok: true, json: async () => ({ ok: true, count: 25 }) };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  };
+
+  vm.runInNewContext(userscript, context);
+  while (pending.length > 0) {
+    await Promise.all(pending.splice(0));
+  }
+
+  assert.equal(importBodies.length, 1);
+  assert.equal(importBodies[0].secret, "secret");
+  assert.equal(importBodies[0].guild, "PizzaWarriors");
+  assert.equal(importBodies[0].realm, "Lordaeron");
+  assert.equal(importBodies[0].html, "<html>roster</html>");
+  assert.notEqual(storage.get("pizzaLogsLastRosterSyncAt:https://pizza-logs-production.up.railway.app"), "0");
+}
+
+verifyUserscriptAutoRunsWithSavedSecret()
+  .then(() => console.log("guild-roster-client-scripts tests passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/guild-roster-sync-windows-task-source.test.ts
+++ b/tests/guild-roster-sync-windows-task-source.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import pkg from "../package.json";
+
+const root = process.cwd();
+const packageScripts = pkg.scripts as Record<string, string>;
+const launcher = readFileSync(path.join(root, "scripts", "guild-roster-sync", "open-warmane-guild-roster-sync.ps1"), "utf8");
+const installer = readFileSync(path.join(root, "scripts", "guild-roster-sync", "install-windows-task.ps1"), "utf8");
+const uninstaller = readFileSync(path.join(root, "scripts", "guild-roster-sync", "uninstall-windows-task.ps1"), "utf8");
+const docs = readFileSync(path.join(root, "docs", "guild-roster-sync-windows-task.md"), "utf8");
+
+assert.match(launcher, /https:\/\/armory\.warmane\.com\/guild\/Pizza\+Warriors\/Lordaeron\/summary/);
+assert.match(launcher, /guild-roster-sync-launcher\.log/);
+assert.match(launcher, /chrome\.exe/i);
+assert.match(launcher, /msedge\.exe/i);
+assert.match(launcher, /Warmane Guild Roster Sync userscript/i);
+assert.match(launcher, /\/guild\/\[\^\/\]\+\/\[\^\/\]\+\/summary/);
+
+assert.match(installer, /PizzaLogsGuildRosterSync/);
+assert.match(installer, /schtasks\.exe/i);
+assert.match(installer, /\/SC"\s*,\s*"MINUTE"/);
+assert.match(installer, /GetFolderPath\("Startup"\)/);
+assert.match(installer, /PizzaLogsGuildRosterSyncAtLogon\.cmd/);
+assert.match(installer, /open-warmane-guild-roster-sync\.ps1/);
+assert.doesNotMatch(installer, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
+
+assert.match(uninstaller, /schtasks\.exe/i);
+assert.match(uninstaller, /\/Delete/);
+assert.match(uninstaller, /PizzaLogsGuildRosterSync/);
+assert.match(uninstaller, /PizzaLogsGuildRosterSyncAtLogon\.cmd/);
+assert.match(uninstaller, /queryExitCode/);
+assert.doesNotMatch(uninstaller, /\*>\s*\$null/);
+assert.doesNotMatch(uninstaller, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
+
+assert.match(docs, /does not store the Pizza Logs admin secret/i);
+assert.match(docs, /Tampermonkey/i);
+assert.match(docs, /persists through restarts/i);
+assert.match(docs, /Startup folder/i);
+assert.match(docs, /guild-roster-sync-launcher\.log/);
+
+assert.equal(
+  packageScripts["guild-roster-sync:install-task"],
+  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guild-roster-sync/install-windows-task.ps1",
+);
+assert.equal(
+  packageScripts["guild-roster-sync:uninstall-task"],
+  "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/guild-roster-sync/uninstall-windows-task.ps1",
+);
+
+console.log("guild-roster-sync-windows-task-source tests passed");

--- a/tests/local-userscript-routes.test.ts
+++ b/tests/local-userscript-routes.test.ts
@@ -52,6 +52,7 @@ async function main() {
   assert.match(gear, new RegExp(PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 
   assert.match(roster, /Pizza Logs Warmane Guild Roster Sync \(Local\)/);
+  assert.match(roster, /\/\/ @version\s+1\.1\.0/);
   assert.match(roster, new RegExp(LOCAL_GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(roster, new RegExp(PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 


### PR DESCRIPTION
## Summary
- add Guild Roster Sync userscript hourly auto-run when a production secret is saved
- add Windows Task Scheduler + Startup folder automation for opening the Warmane guild page hourly/logon
- document setup and add source/tests for roster automation, plus harden gear/roster uninstall scripts when tasks are missing

## Validation
- npx ts-node --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts
- npx ts-node --project tsconfig.seed.json tests\guild-roster-sync-windows-task-source.test.ts
- npx ts-node --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts
- npx ts-node --project tsconfig.seed.json tests\local-userscript-routes.test.ts
- npx ts-node --project tsconfig.seed.json --compiler-options '{"jsx":"react-jsx"}' tests\guild-roster-admin-panel.test.ts
- npm run type-check
- npm run lint
- npm run build
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1 -WhatIf
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\uninstall-windows-task.ps1 -WhatIf
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\uninstall-windows-task.ps1 -WhatIf
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1
- schtasks.exe /Query /TN PizzaLogsGuildRosterSync /FO LIST /V

## Notes
- The scheduled task stores no Pizza Logs admin secret, database URL, Railway token, or other production secret.
- Neil still needs the production Guild Roster Sync userscript installed from /admin and must click Sync roster once if the production admin secret is not already saved.