### PR TITLE
Quiet Warmane sync launchers

### DIFF
--- a/Pizza Logs HQ/02 Build Log/Latest Handoff.md
+++ b/Pizza Logs HQ/02 Build Log/Latest Handoff.md
@@ -25,8 +25,9 @@
   clutter the DPS/HPS by encounter trend.
 - Gear Sync now refreshes every known Pizza Logs character from Warmane once per
   hour, instead of only importing players with missing or incomplete cached gear.
-- Local Windows automation can now open Warmane character and guild roster pages
-  hourly and at logon so the browser userscripts can run after restarts.
+- Local Windows automation now opens Warmane character and guild roster pages at
+  logon with hidden Startup launchers; the browser userscripts keep hourly
+  refreshes running inside the existing Warmane tabs.
 - README now includes a high-resolution app preview captured from a fresh local Next server on `http://127.0.0.1:3004`.
 - README now links to the GitHub wiki, and the wiki has been refreshed for current upload, roster, gear, parser, roadmap, and branch workflow details.
 - Local repo-root launchers:
@@ -53,13 +54,34 @@
 - Supported roster/gear refresh path is browser-assisted userscripts from `/admin`.
 - Player avatars intentionally use class icons, with initials fallback when class data or icon loading is unavailable.
 - Production userscripts still post to Railway production; local userscripts post to `http://127.0.0.1:3001`.
-- Gear userscript v1.8.0 requests the full refresh queue hourly; roster
-  userscript v1.1.0 stores admin secrets per Pizza Logs target origin, shows the
-  target in the Warmane panel, and auto-runs hourly after a secret is saved.
+- Gear userscript v1.8.1 requests the full refresh queue hourly from the
+  existing Warmane tab; roster userscript v1.1.1 stores admin secrets per Pizza
+  Logs target origin, shows the target in the Warmane panel, and schedules
+  hourly refreshes inside the existing Warmane tab after a secret is saved.
 - Windows gear automation scripts live under `scripts/gear-sync/`; docs live in
   `docs/gear-sync-windows-task.md`.
 - Windows guild roster automation scripts live under `scripts/guild-roster-sync/`;
   docs live in `docs/guild-roster-sync-windows-task.md`.
+
+## Quiet Warmane Sync Launch Session
+
+- Investigated Neil's report that hourly sync was opening too many browser tabs
+  and flashing command prompts during gaming.
+- Root cause: the Windows tasks launched `powershell.exe` directly every hour,
+  and Startup used visible `.cmd` launchers; each browser URL launch could create
+  a fresh tab.
+- Moved hourly repeat ownership into the Gear and Guild Roster userscripts so an
+  already-open Warmane tab keeps syncing.
+- Bumped Gear Sync to `1.8.1` and Guild Roster Sync to `1.1.1`.
+- Updated both Windows installers to remove the old hourly scheduled task and
+  replace the visible `.cmd` Startup launcher with a hidden `.vbs` wrapper using
+  `WScript.Shell`.
+- Reinstalled the local launchers on Neil's machine.
+- Removed the local `PizzaLogsGearSync` and `PizzaLogsGuildRosterSync` scheduled
+  tasks.
+- Removed the old Startup `.cmd` launchers and created:
+  - `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.vbs`
+  - `C:\Users\neil_\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.vbs`
 - The cinematic intro now uses generated video assets from `animations/source/Veo.mp4` instead of the retired `public/intro` asset set.
 
 ## Tampermonkey Auth Session
@@ -247,6 +269,18 @@
 | `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1` | Passed; registered `PizzaLogsGuildRosterSync` and created Startup launcher |
 | `schtasks.exe /Query /TN PizzaLogsGuildRosterSync /FO LIST /V` | Passed; task is ready and repeats every 1 hour |
 | Guild roster startup launcher content check | Passed; points at `scripts\guild-roster-sync\open-warmane-guild-roster-sync.ps1` |
+| `npx ts-node --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed for Gear Sync `1.8.1` in-tab hourly timer |
+| `npx ts-node --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed for Guild Roster Sync `1.1.1` in-tab hourly timer |
+| `npx ts-node --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts` | Passed for hidden VBS startup launcher behavior |
+| `npx ts-node --project tsconfig.seed.json tests\guild-roster-sync-windows-task-source.test.ts` | Passed for hidden VBS startup launcher behavior |
+| `npx ts-node --project tsconfig.seed.json tests\local-userscript-routes.test.ts` | Passed for local userscript versions |
+| JSX-aware `tests\gear-import-bookmarklet.test.ts` | Passed |
+| JSX-aware `tests\guild-roster-admin-panel.test.ts` | Passed |
+| Quiet gear launcher install | Passed; removed `PizzaLogsGearSync`, removed `.cmd`, created `.vbs` |
+| Quiet guild roster launcher install | Passed; removed `PizzaLogsGuildRosterSync`, removed `.cmd`, created `.vbs` |
+| `schtasks.exe /Query /TN PizzaLogsGearSync` | Passed; task is absent |
+| `schtasks.exe /Query /TN PizzaLogsGuildRosterSync` | Passed; task is absent |
+| Startup VBS content checks | Passed; both use `powershell.exe -WindowStyle Hidden` with escaped script and target URL arguments |
 | Local `GET http://127.0.0.1:3001/guild-roster?page=2` | Passed with HTTP 200 after dev server compile |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts` | Passed |
 | `node node_modules\ts-node\dist\bin.js --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts` | Passed |
@@ -287,14 +321,18 @@
 - Hourly full gear and roster refreshes depend on a local Windows user/browser
   profile with the production userscripts installed and the correct admin secret
   saved.
-- The current-user task is interactive only. It persists through restarts, but it
-  cannot run before Neil logs into Windows.
+- Hourly browser timers need the Warmane gear/roster tabs to remain open. If a
+  tab is closed, refresh resumes after Neil opens it again or after the next
+  Windows logon launcher opens it.
+- Browser background-tab throttling can delay a sync while the browser or PC is
+  suspended.
 
 ## Exact Next Step
 
-Review the `codex-dev` to `main` PR for the local Windows roster automation.
-After deployment, reinstall/update the production Guild Roster Sync userscript
-from `/admin`, open the Warmane Pizza Warriors guild summary page, and click
-`Sync roster` once if the admin secret is not already saved. The scheduled task
-can then keep opening Warmane hourly after restarts. Neil merges into `main`
-only after review; Codex does not merge or push `main` directly.
+Review the `codex-dev` to `main` PR for quiet Warmane sync launch behavior.
+After deployment, reinstall/update both production userscripts from `/admin`,
+open one Warmane character tab and the Pizza Warriors guild tab, and click
+`Sync now` / `Sync roster` once if the admin secret is not already saved. Keep
+those tabs open for hourly refreshes without recurring Windows tab launches.
+Neil merges into `main` only after review; Codex does not merge or push `main`
+directly.

--- a/Pizza Logs HQ/03 Current Focus/Now.md
+++ b/Pizza Logs HQ/03 Current Focus/Now.md
@@ -2,7 +2,7 @@
 
 ## Active Focus
 
-The current session added local Windows automation for Guild Roster Sync, matching the Gear Sync setup. Direct local CLI requests to Warmane still return 403, so the automation opens real Warmane pages hourly and at Windows logon; the browser userscripts handle the actual refreshes. Parser reliability remains the highest-risk product area.
+The current session quieted the local Windows Warmane sync automation. Direct local CLI requests to Warmane still return 403, so Windows now opens Warmane pages only at logon with hidden Startup launchers, and the browser userscripts keep hourly refreshes running inside the existing Warmane tabs. Parser reliability remains the highest-risk product area.
 
 README visual refresh: added a high-resolution `docs/assets/readme-screenshot.png` preview to the public README. The screenshot was captured from a fresh local Next dev server on `http://127.0.0.1:3004` while the parser service was listening on `127.0.0.1:8000`.
 
@@ -14,6 +14,14 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 
 ## This Session
 
+- Investigated Neil's report that command prompts interrupted gaming and hourly sync opened too many Warmane tabs.
+- Confirmed the root cause was hourly `powershell.exe` scheduled tasks plus visible `.cmd` Startup launchers.
+- Changed Gear Sync and Guild Roster Sync so the browser userscripts schedule the next hourly run inside the already-open Warmane tab.
+- Bumped Gear Sync to `1.8.1` and Guild Roster Sync to `1.1.1`.
+- Updated Windows installers to remove the old hourly scheduled tasks and create hidden `.vbs` Startup launchers.
+- Reinstalled the local quiet launchers; `PizzaLogsGearSync` and `PizzaLogsGuildRosterSync` scheduled tasks are now absent.
+- Removed the old Startup `.cmd` files and created `PizzaLogsGearSyncAtLogon.vbs` plus `PizzaLogsGuildRosterSyncAtLogon.vbs`.
+- Verified both VBS launchers call `powershell.exe -WindowStyle Hidden`.
 - Extended the Guild Roster Sync userscript so saved-secret Warmane guild page visits auto-sync at most once per hour.
 - Bumped Guild Roster Sync to `1.1.0`.
 - Added Windows guild roster automation scripts under `scripts/guild-roster-sync/`.
@@ -143,9 +151,9 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 | README app preview | DONE | Added `docs/assets/readme-screenshot.png` and linked it from `README.md` |
 | README and wiki metadata refresh | DONE | Updated public README link and GitHub wiki content |
 | Userscript target-specific secrets | DONE | Gear `1.7.1`, roster `1.0.5`; local/prod secrets no longer collide |
-| Hourly Gear Sync refresh-all | DONE | Gear `1.8.0` refreshes all known DB/roster characters hourly from Warmane |
-| Windows Gear Sync scheduled task | DONE | Task Scheduler opens a Warmane character page hourly; Startup folder opens it at logon |
-| Windows Guild Roster Sync scheduled task | DONE | Task Scheduler opens the Warmane guild roster page hourly; Startup folder opens it at logon |
+| Hourly Gear Sync refresh-all | DONE | Gear `1.8.1` refreshes all known DB/roster characters hourly from an existing Warmane tab |
+| Windows Gear Sync quiet launcher | DONE | Hidden Startup VBS opens a Warmane character page at logon; no hourly Windows tab opener |
+| Windows Guild Roster Sync quiet launcher | DONE | Hidden Startup VBS opens the Warmane guild roster page at logon; no hourly Windows tab opener |
 | ICC difficulty marker fix | DONE | Saurfang `Rune of Blood` stays normal-capable; Saurfang `Scent of Blood` IDs and Valithria `Twisted Nightmares` now mark heroic |
 | Session player chart kill filter | DONE | DPS/HPS by encounter chart excludes wipes; Encounter Breakdown still lists all pulls |
 
@@ -155,9 +163,7 @@ Codex works on `codex-dev`, pushes `origin/codex-dev`, and opens PRs into `main`
 - Confirm the fresh docs-only PR posts to Slack now that `PR_SLACK_WEBHOOK_URL` is configured.
 - Add hard server-side upload size enforcement.
 - Decide whether app-level upload rate limiting is needed or Railway-level controls are enough.
-- Use `scripts/gear-sync/install-windows-task.ps1` or `npm run gear-sync:install-task` to keep Gear Sync running hourly from Windows.
-- After the Windows automation PR deploys, reinstall/update the production Gear Sync userscript from `/admin`; open any Warmane character page and click `Sync now` once if the admin secret is not saved.
-- After the roster automation PR deploys, reinstall/update the production Guild Roster Sync userscript from `/admin`; open the Warmane Pizza Warriors guild page and click `Sync roster` once if the admin secret is not saved.
+- After the quiet sync PR deploys, reinstall/update the production Gear Sync and Guild Roster Sync userscripts from `/admin`; keep one Warmane character tab and one guild page tab open for hourly refreshes.
 - After this parser fix deploys, reprocess or re-upload the affected latest raid so stored Saurfang and Valithria difficulties are regenerated.
 - Absorbs remain future parser work.
 - Add more encounter-specific useful-damage exclusions as real Skada comparison data becomes available.

--- a/Pizza Logs HQ/05 Features/Feature Status.md
+++ b/Pizza Logs HQ/05 Features/Feature Status.md
@@ -22,7 +22,7 @@ This file is the single source for shipped features, active backlog, and technic
 | Item metadata | AzerothCore `item_template` import populates `wow_items`; no runtime Wowhead API dependency |
 | Gear/userscript import | Browser-assisted Warmane Gear Sync refreshes known character gear hourly and fills icon gaps |
 | Roster/userscript import | Browser-assisted Warmane Guild Roster Sync refreshes roster rows hourly after a secret is saved |
-| Windows Warmane sync tasks | Task Scheduler opens Warmane character and guild roster pages hourly, and Startup folder opens them at logon so userscripts can run after restarts |
+| Windows Warmane sync launchers | Hidden Startup launchers open Warmane character and guild roster pages at logon; userscripts keep hourly refreshes inside existing tabs |
 | Class-icon avatars | Player avatars use WoW class icons with initials fallback |
 | ICC ordering | Shared helpers keep ICC boss displays in progression order where appropriate |
 | Local test server helpers | Windows scripts start/stop web and parser test servers |
@@ -33,7 +33,7 @@ This file is the single source for shipped features, active backlog, and technic
 
 | Item | Status |
 |---|---|
-| Warmane production data freshness | Browser-assisted Windows Task Scheduler automation is available for gear and roster; fully headless sync remains future work |
+| Warmane production data freshness | Browser-assisted hidden Startup launchers and in-tab hourly userscript timers are available for gear and roster; fully headless sync remains future work |
 | Absorbs | Future parser work; not currently implemented |
 
 ## Backlog

--- a/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
+++ b/Pizza Logs HQ/09 Bugs and Blockers/Known Issues.md
@@ -12,7 +12,7 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | Upload rate limiting is not implemented | Abuse could create parser/DB load | Prefer Railway-level controls first; add app logic only if needed |
 | Absorbs are not implemented | Disc priest contribution can be lower than Skada combined healing+absorbs views | Future parser work based on Skada `Absorbs.lua`; keep separate from healing done |
 | Role detection is rough | Hybrids/self-healing classes can be mislabeled; tanks are not inferred | Replace upload-time heal/damage ratio with better class/spec/combat evidence |
-| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway or plain CLI requests | Supported path is browser-assisted userscripts, Windows Task Scheduler launches for gear and roster, and cached DB snapshots |
+| Warmane direct server fetches can fail with Cloudflare/403 | Gear/roster refreshes are unreliable from Railway or plain CLI requests | Supported path is browser-assisted userscripts, hidden Windows Startup launchers for gear and roster, and cached DB snapshots |
 | Some heroic/Gunship difficulty evidence is absent | Certain pulls cannot be classified perfectly from logs alone | Use direct marker evidence first; keep normal-looking non-Gunship fallback attempts normal; document uncertainty |
 | Orphaned pets can remain unmatched | Small DPS mismatches when pets were active before log start | Keep Skada-aligned owner remap when summon evidence exists |
 
@@ -52,9 +52,10 @@ No confirmed app-breaking bugs are active as of the documentation audit.
 | PR description headings showed unsupported Slack markdown | Added markdown normalization so GitHub headings become Slack bold labels |
 | Local and production Warmane userscripts shared the same saved admin secret | Gear `1.7.1` and roster `1.0.5` now use target-specific localStorage keys, show the target host, and clear the legacy shared key on unauthorized responses |
 | Gear Sync skipped already cached characters | Gear `1.8.0` requests refresh-all mode hourly so complete cached players are refreshed from Warmane too |
-| Gear Sync only ran when Neil manually visited Warmane | Added Windows automation that opens a Warmane character page hourly through Task Scheduler and at logon through the Startup folder |
-| Guild Roster Sync only ran when Neil manually visited Warmane | Roster `1.1.0` auto-runs hourly with a saved target secret, and Windows automation opens the Warmane guild roster page hourly through Task Scheduler and at logon through the Startup folder |
+| Gear Sync only ran when Neil manually visited Warmane | Gear `1.8.1` auto-runs hourly inside an existing Warmane tab with a saved target secret; hidden Startup launcher opens the page at logon |
+| Guild Roster Sync only ran when Neil manually visited Warmane | Roster `1.1.1` auto-runs hourly inside an existing Warmane tab with a saved target secret; hidden Startup launcher opens the guild page at logon |
 | Windows sync uninstall scripts errored when no task existed | Gear and roster uninstall scripts now treat missing scheduled tasks/startup launchers as clean no-ops |
+| Warmane sync opened recurring tabs and flashed command prompts | Gear `1.8.1` and roster `1.1.1` schedule hourly runs inside existing Warmane tabs; Windows now uses hidden Startup VBS launchers and removes the old hourly scheduled tasks |
 
 ## Not Bugs
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Warmane live server fetches are best-effort and may fail from Railway or local s
 - Warmane Gear Sync userscript for hourly current-equipment refreshes and icon backfill.
 - Warmane Guild Roster userscript for hourly roster rank, class, race, professions, and member refreshes.
 
-For Windows persistence, the repo includes a Task Scheduler setup that opens a
-Warmane character page hourly so the Gear Sync userscript can run after restarts:
+For Windows persistence, the repo includes quiet Startup launchers that open
+Warmane once after logon; the userscripts then refresh hourly inside the existing tabs:
 [`docs/gear-sync-windows-task.md`](docs/gear-sync-windows-task.md).
 The guild roster has the same local Windows automation:
 [`docs/guild-roster-sync-windows-task.md`](docs/guild-roster-sync-windows-task.md).

--- a/app/admin/GearImportBookmarklet.tsx
+++ b/app/admin/GearImportBookmarklet.tsx
@@ -8,15 +8,16 @@ export function GearImportBookmarklet() {
         <p className="text-sm text-text-secondary mt-1">
           Install the hosted userscript with Tampermonkey, then open Warmane Armory. It adds a
           small Pizza Logs sync panel and refreshes every known Pizza Logs character once per
-          hour through Warmane&apos;s browser-accessible API. The admin secret is stored in
-          browser localStorage on Warmane so auto-sync can run.
+          hour through Warmane&apos;s browser-accessible API. Keep one Warmane character tab open;
+          it will reuse that tab for hourly sync instead of relying on Windows to open new tabs.
+          The admin secret is stored in browser localStorage on Warmane so auto-sync can run.
         </p>
       </div>
       <ol className="list-decimal space-y-1 pl-5 text-sm text-text-secondary">
         <li>Install Tampermonkey or another userscript manager.</li>
         <li>Open the hosted gear install URL below and accept the install/update prompt.</li>
         <li>Open any Warmane Armory character page and click Sync now once to save the admin secret.</li>
-        <li>After that, visiting Warmane Armory will auto-sync at most once per hour.</li>
+        <li>After that, leaving that Warmane tab open will auto-sync at most once per hour.</li>
       </ol>
       <div className="space-y-2">
         <div className="flex flex-wrap gap-2">

--- a/app/admin/GuildRosterSyncPanel.tsx
+++ b/app/admin/GuildRosterSyncPanel.tsx
@@ -30,9 +30,9 @@ export function GuildRosterSyncPanel({
         Warmane blocks server-side requests from Railway, so the roster is synced via a
         browser userscript. Install the userscript below, open the Warmane guild page, and
         click the floating Pizza Logs Roster Sync button once to save the admin secret.
-        After that, opening the guild page can auto-sync the roster hourly. The public
-        roster page reads only from our database, so it loads even when Warmane is
-        unavailable.
+        After that, leaving the guild page open can auto-sync the roster hourly without
+        Windows opening a new tab each time. The public roster page reads only from our
+        database, so it loads even when Warmane is unavailable.
       </p>
 
       <div className="flex flex-wrap items-center gap-4">
@@ -47,7 +47,7 @@ export function GuildRosterSyncPanel({
           <p className="text-sm text-text-secondary mt-1">
             Install this userscript with Tampermonkey, then open the Warmane guild page below.
             The floating Pizza Logs Roster Sync button will import the full roster into Pizza Logs,
-            and saved-secret visits can auto-sync the roster hourly.
+            and a saved-secret Warmane tab can keep auto-syncing the roster hourly.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">

--- a/docs/gear-sync-windows-task.md
+++ b/docs/gear-sync-windows-task.md
@@ -2,23 +2,25 @@
 
 Pizza Logs can run Warmane gear refreshes from Neil's Windows PC without putting
 anything on Railway. Warmane blocks plain server-side and CLI requests with 403,
-so the local automation opens a real Warmane character page and lets the
-Tampermonkey Gear Sync userscript do the refresh from the browser.
+so the local automation opens a real Warmane character page at logon and lets
+the Tampermonkey Gear Sync userscript do the refresh from the browser.
 
-This setup persists through restarts by combining one hourly Task Scheduler task
-with one Startup folder launcher. Both run when the Windows user is logged in.
+This setup persists through restarts with a quiet Startup folder launcher. The
+userscript keeps refreshing hourly inside the existing Warmane tab, so Windows
+does not create a new browser tab every hour.
 
 ## What It Does
 
-- Opens a Warmane character page once per hour.
-- Opens the same page at Windows logon from the Startup folder.
+- Opens a Warmane character page at Windows logon from the Startup folder.
+- Reuses the existing Warmane tab after that by letting the userscript schedule
+  the hourly refresh in-page.
 - Relies on the installed Pizza Logs Gear Sync userscript to refresh all known
   Pizza Logs characters.
 - Writes launcher logs to `.sync-agent-logs/gear-sync-launcher.log`.
 
-The scheduled task does not store the Pizza Logs admin secret, `DATABASE_URL`,
-Railway tokens, or other production secrets. The admin secret remains wherever
-the browser userscript stores it for `armory.warmane.com`.
+The launcher does not store the Pizza Logs admin secret, `DATABASE_URL`, Railway
+tokens, or other production secrets. The admin secret remains wherever the
+browser userscript stores it for `armory.warmane.com`.
 
 ## Prerequisites
 
@@ -27,7 +29,7 @@ the browser userscript stores it for `armory.warmane.com`.
 3. Click `Sync now` once and enter the production admin secret.
 4. Confirm Gear Sync shows the production target.
 
-## Install The Task
+## Install The Quiet Launcher
 
 From the repo root:
 
@@ -41,7 +43,7 @@ Or through npm:
 npm run gear-sync:install-task
 ```
 
-By default the task opens:
+By default the launcher opens:
 
 ```text
 https://armory.warmane.com/character/Lausudo/Lordaeron/summary
@@ -62,9 +64,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-
 ## Run Or Inspect
 
 ```powershell
-Start-ScheduledTask -TaskName PizzaLogsGearSync
-Get-ScheduledTask -TaskName PizzaLogsGearSync
-Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.cmd"
+Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGearSyncAtLogon.vbs"
 Get-Content .\.sync-agent-logs\gear-sync-launcher.log -Tail 20
 ```
 
@@ -86,6 +86,7 @@ npm run gear-sync:uninstall-task
 - It cannot run before the Windows user logs in, because the browser and
   Tampermonkey need an interactive user profile.
 - If the PC is asleep or offline, the Startup folder launcher catches the next
-  restart or login, and the hourly task resumes after Windows is active.
-- If the browser opens many Warmane tabs, close old ones periodically or change
-  the target browser/profile setup.
+  restart or login. If the Warmane tab is closed later, open it again manually
+  or rerun the installer with `-RunNow`.
+- Background tab timers are owned by the browser; if Windows or the browser
+  suspends the tab, the next sync can be delayed until the tab wakes.

--- a/docs/guild-roster-sync-windows-task.md
+++ b/docs/guild-roster-sync-windows-task.md
@@ -2,24 +2,26 @@
 
 Pizza Logs can refresh the PizzaWarriors/Lordaeron roster from Neil's Windows
 PC without putting anything on Railway. Warmane blocks plain server-side and CLI
-requests with 403, so this automation opens the real Warmane guild page and
-lets the Tampermonkey Guild Roster Sync userscript do the import from the
-browser.
+requests with 403, so this automation opens the real Warmane guild page at
+logon and lets the Tampermonkey Guild Roster Sync userscript do the import from
+the browser.
 
-This setup persists through restarts by combining one hourly Task Scheduler task
-with one Startup folder launcher. Both run when the Windows user is logged in.
+This setup persists through restarts with a quiet Startup folder launcher. The
+userscript keeps refreshing hourly inside the existing Warmane tab, so Windows
+does not create a new browser tab every hour.
 
 ## What It Does
 
-- Opens the Warmane Pizza Warriors guild page once per hour.
-- Opens the same page at Windows logon from the Startup folder.
+- Opens the Warmane Pizza Warriors guild page at Windows logon from the Startup folder.
+- Reuses the existing Warmane tab after that by letting the userscript schedule
+  the hourly refresh in-page.
 - Relies on the installed Pizza Logs Guild Roster Sync userscript to import the
   full roster.
 - Writes launcher logs to `.sync-agent-logs/guild-roster-sync-launcher.log`.
 
-The scheduled task does not store the Pizza Logs admin secret, `DATABASE_URL`,
-Railway tokens, or other production secrets. The admin secret remains wherever
-the browser userscript stores it for `armory.warmane.com`.
+The launcher does not store the Pizza Logs admin secret, `DATABASE_URL`, Railway
+tokens, or other production secrets. The admin secret remains wherever the
+browser userscript stores it for `armory.warmane.com`.
 
 ## Prerequisites
 
@@ -28,7 +30,7 @@ the browser userscript stores it for `armory.warmane.com`.
 3. Click `Sync roster` once and enter the production admin secret.
 4. Confirm Roster Sync shows the production target.
 
-## Install The Task
+## Install The Quiet Launcher
 
 From the repo root:
 
@@ -42,7 +44,7 @@ Or through npm:
 npm run guild-roster-sync:install-task
 ```
 
-By default the task opens:
+By default the launcher opens:
 
 ```text
 https://armory.warmane.com/guild/Pizza+Warriors/Lordaeron/summary
@@ -57,9 +59,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\
 ## Run Or Inspect
 
 ```powershell
-Start-ScheduledTask -TaskName PizzaLogsGuildRosterSync
-Get-ScheduledTask -TaskName PizzaLogsGuildRosterSync
-Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.cmd"
+Get-ChildItem "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\PizzaLogsGuildRosterSyncAtLogon.vbs"
 Get-Content .\.sync-agent-logs\guild-roster-sync-launcher.log -Tail 20
 ```
 
@@ -81,6 +81,9 @@ npm run guild-roster-sync:uninstall-task
 - It cannot run before the Windows user logs in, because the browser and
   Tampermonkey need an interactive user profile.
 - If the PC is asleep or offline, the Startup folder launcher catches the next
-  restart or login, and the hourly task resumes after Windows is active.
+  restart or login. If the Warmane tab is closed later, open it again manually
+  or rerun the installer with `-RunNow`.
+- Background tab timers are owned by the browser; if Windows or the browser
+  suspends the tab, the next sync can be delayed until the tab wakes.
 - The roster userscript must have the correct production admin secret saved once
   before automatic runs can post to Pizza Logs.

--- a/lib/armory-gear-client-scripts.ts
+++ b/lib/armory-gear-client-scripts.ts
@@ -345,6 +345,7 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
       panel: null as HTMLDivElement | null,
       status: null as HTMLDivElement | null,
       button: null as HTMLButtonElement | null,
+      autoTimer: null as ReturnType<typeof setTimeout> | null,
     };
 
     const setStatus = function setStatus(message: string) {
@@ -399,7 +400,9 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
         "color:#f1d36b",
         "cursor:pointer",
       ].join(";");
-      button.addEventListener("click", () => runSync(true));
+      button.addEventListener("click", () => {
+        runSync(true).finally(scheduleNextAutoSync);
+      });
 
       const reset = document.createElement("button");
       reset.type = "button";
@@ -409,6 +412,8 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
         localStorage.removeItem(secretKey);
         localStorage.removeItem(legacySecretKey);
         localStorage.removeItem(lastRunKey);
+        if (state.autoTimer !== null) clearTimeout(state.autoTimer);
+        state.autoTimer = null;
         setStatus("Secret cleared. Click Sync now to enter it again.");
       });
 
@@ -606,24 +611,43 @@ export function buildUserscript(options: UserscriptOptions = {}): string {
       }
     }
 
-    buildPanel();
+    const scheduleNextAutoSync = function scheduleNextAutoSync() {
+      if (state.autoTimer !== null) {
+        clearTimeout(state.autoTimer);
+        state.autoTimer = null;
+      }
 
-    const lastRun = Number(localStorage.getItem(lastRunKey) || "0");
-    const hasSecret = Boolean(localStorage.getItem(secretKey));
-    if (hasSecret && Date.now() - lastRun > autoIntervalMs) {
-      setTimeout(() => runSync(false), 2500);
-    } else if (!hasSecret) {
-      setStatus("Click Sync now once to save the admin secret and enable auto-sync.");
-    } else {
-      setStatus("Auto-sync armed. Click Sync now to force a refresh.");
-    }
+      const hasSecret = Boolean(localStorage.getItem(secretKey));
+      if (!hasSecret) {
+        setStatus("Click Sync now once to save the admin secret and enable auto-sync.");
+        return;
+      }
+
+      const lastRun = Number(localStorage.getItem(lastRunKey) || "0");
+      const elapsed = Date.now() - lastRun;
+      const delay = lastRun > 0 ? Math.max(5000, autoIntervalMs - elapsed) : 2500;
+
+      state.autoTimer = setTimeout(() => {
+        state.autoTimer = null;
+        return runSync(false).finally(scheduleNextAutoSync);
+      }, delay);
+
+      if (delay <= 5000) {
+        setStatus("Auto-sync will run in this Warmane tab.");
+      } else {
+        setStatus("Auto-sync armed in this Warmane tab. Click Sync now to force a refresh.");
+      }
+    };
+
+    buildPanel();
+    scheduleNextAutoSync();
   };
 
   return [
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Gear Auto Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.8.0",
+    "// @version      1.8.1",
     "// @description  Hourly refresh Pizza Logs gear cache from Warmane Armory pages.",
     "// @match        https://armory.warmane.com/character/*",
     "// @match        http://armory.warmane.com/character/*",

--- a/lib/guild-roster-client-scripts.ts
+++ b/lib/guild-roster-client-scripts.ts
@@ -39,6 +39,7 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
       panel: null as HTMLDivElement | null,
       status: null as HTMLDivElement | null,
       button: null as HTMLButtonElement | null,
+      autoTimer: null as ReturnType<typeof setTimeout> | null,
     };
 
     const setStatus = function setStatus(message: string) {
@@ -180,7 +181,9 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
         "color:#f1d36b",
         "cursor:pointer",
       ].join(";");
-      button.addEventListener("click", runRosterSync);
+      button.addEventListener("click", () => {
+        runRosterSync().finally(scheduleNextAutoSync);
+      });
 
       const reset = document.createElement("button");
       reset.type = "button";
@@ -190,6 +193,8 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
         localStorage.removeItem(secretKey);
         localStorage.removeItem(legacySecretKey);
         localStorage.removeItem(lastRunKey);
+        if (state.autoTimer !== null) clearTimeout(state.autoTimer);
+        state.autoTimer = null;
         setStatus("Secret cleared. Click Sync roster to enter it again.");
       });
 
@@ -202,19 +207,41 @@ function buildRosterScriptBody(autoRun: boolean, pizzaLogsOrigin = PIZZA_LOGS_OR
 
     buildPanel();
 
+    const scheduleNextAutoSync = function scheduleNextAutoSync() {
+      if (state.autoTimer !== null) {
+        clearTimeout(state.autoTimer);
+        state.autoTimer = null;
+      }
+
+      const hasSecret = Boolean(localStorage.getItem(secretKey));
+      if (!hasSecret) {
+        setStatus("Click Sync roster once to save the admin secret and enable auto-sync.");
+        return;
+      }
+
+      const lastRun = Number(localStorage.getItem(lastRunKey) || "0");
+      const elapsed = Date.now() - lastRun;
+      const delay = lastRun > 0 ? Math.max(5000, autoIntervalMs - elapsed) : 2500;
+
+      state.autoTimer = setTimeout(() => {
+        state.autoTimer = null;
+        return runRosterSync().finally(scheduleNextAutoSync);
+      }, delay);
+
+      if (delay <= 5000) {
+        setStatus("Roster auto-sync will run in this Warmane tab.");
+      } else {
+        setStatus("Roster auto-sync armed in this Warmane tab. Click Sync roster to force a refresh.");
+      }
+    };
+
     const autoRunFlag: string = "__AUTO_RUN__";
     if (autoRunFlag === "true") {
-      setTimeout(runRosterSync, 500);
+      setTimeout(() => {
+        return runRosterSync().finally(scheduleNextAutoSync);
+      }, 500);
     } else {
-      const lastRun = Number(localStorage.getItem(lastRunKey) || "0");
-      const hasSecret = Boolean(localStorage.getItem(secretKey));
-      if (hasSecret && Date.now() - lastRun > autoIntervalMs) {
-        setTimeout(runRosterSync, 2500);
-      } else if (!hasSecret) {
-        setStatus("Click Sync roster once to save the admin secret and enable auto-sync.");
-      } else {
-        setStatus("Roster auto-sync armed. Click Sync roster to force a refresh.");
-      }
+      scheduleNextAutoSync();
     }
   };
 
@@ -243,7 +270,7 @@ export function buildGuildRosterUserscript(options: GuildRosterUserscriptOptions
     "// ==UserScript==",
     `// @name         Pizza Logs Warmane Guild Roster Sync${nameSuffix}`,
     `// @namespace    ${pizzaLogsOrigin}`,
-    "// @version      1.1.0",
+    "// @version      1.1.1",
     "// @description  Hourly sync Pizza Logs guild roster from Warmane Armory in-browser.",
     "// @match        https://armory.warmane.com/guild/*",
     "// @match        http://armory.warmane.com/guild/*",

--- a/scripts/gear-sync/install-windows-task.ps1
+++ b/scripts/gear-sync/install-windows-task.ps1
@@ -2,8 +2,6 @@
 param(
   [string]$TaskName = "PizzaLogsGearSync",
   [string]$TargetUrl = "https://armory.warmane.com/character/Lausudo/Lordaeron/summary",
-  [int]$IntervalMinutes = 60,
-  [int]$StartDelayMinutes = 5,
   [string]$BrowserPath = "",
   [switch]$UseDefaultBrowser,
   [switch]$RunNow
@@ -11,17 +9,15 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-if ($IntervalMinutes -lt 15) {
-  throw "IntervalMinutes must be at least 15."
-}
-
 $launcherPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "open-warmane-gear-sync.ps1")).Path
-$startAt = (Get-Date).AddMinutes($StartDelayMinutes).ToString("HH:mm")
 $startupFolder = [Environment]::GetFolderPath("Startup")
-$startupCommandPath = Join-Path $startupFolder "PizzaLogsGearSyncAtLogon.cmd"
+$startupScriptPath = Join-Path $startupFolder "PizzaLogsGearSyncAtLogon.vbs"
+$legacyStartupCommandPath = Join-Path $startupFolder "PizzaLogsGearSyncAtLogon.cmd"
 
 $taskArguments = @(
   "-NoProfile",
+  "-WindowStyle",
+  "Hidden",
   "-ExecutionPolicy",
   "Bypass",
   "-File",
@@ -41,6 +37,17 @@ if ($UseDefaultBrowser) {
 $taskCommand = "powershell.exe $($taskArguments -join ' ')"
 $schtasks = "schtasks.exe"
 
+function Test-ExistingTask {
+  $previousErrorActionPreference = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  try {
+    & $schtasks /Query /TN $TaskName > $null 2>&1
+    return $LASTEXITCODE -eq 0
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+}
+
 function Invoke-Schtasks {
   param([string[]]$Arguments)
 
@@ -50,28 +57,40 @@ function Invoke-Schtasks {
   }
 }
 
-if ($PSCmdlet.ShouldProcess($TaskName, "Register hourly Pizza Logs Gear Sync scheduled task")) {
-  Invoke-Schtasks @(
-    "/Create",
-    "/TN", $TaskName,
-    "/SC", "MINUTE",
-    "/MO", "$IntervalMinutes",
-    "/ST", $startAt,
-    "/TR", $taskCommand,
-    "/F"
-  )
+function Remove-ExistingTask {
+  if (Test-ExistingTask) {
+    if ($PSCmdlet.ShouldProcess($TaskName, "Delete old hourly Pizza Logs Gear Sync scheduled task")) {
+      Invoke-Schtasks @("/Delete", "/TN", $TaskName, "/F")
+      Write-Host "Removed old scheduled task '$TaskName'."
+    }
+  }
+}
 
-  Set-Content -LiteralPath $startupCommandPath -Value @(
-    "@echo off",
-    $taskCommand
+function ConvertTo-VbsStringLiteral {
+  param([string]$Value)
+  $escaped = $Value.Replace('"', '""')
+  return "`"$escaped`""
+}
+
+if ($PSCmdlet.ShouldProcess($startupScriptPath, "Create quiet Pizza Logs Gear Sync startup launcher")) {
+  Remove-ExistingTask
+
+  if (Test-Path -LiteralPath $legacyStartupCommandPath) {
+    Remove-Item -LiteralPath $legacyStartupCommandPath -Force
+    Write-Host "Removed legacy startup launcher '$legacyStartupCommandPath'."
+  }
+
+  $vbsCommand = ConvertTo-VbsStringLiteral $taskCommand
+  Set-Content -LiteralPath $startupScriptPath -Value @(
+    'Set shell = CreateObject("WScript.Shell")',
+    "shell.Run $vbsCommand, 0, False"
   ) -Encoding ascii
 
   if ($RunNow) {
-    Invoke-Schtasks @("/Run", "/TN", $TaskName)
+    Start-Process -FilePath "powershell.exe" -ArgumentList $taskArguments -WindowStyle Hidden
   }
 
-  Write-Host "Registered scheduled task '$TaskName'."
-  Write-Host "Created startup launcher '$startupCommandPath'."
+  Write-Host "Created quiet startup launcher '$startupScriptPath'."
   Write-Host "Target URL: $TargetUrl"
-  Write-Host "Interval: every $IntervalMinutes minutes, plus at logon."
+  Write-Host "The browser userscript now owns the hourly refresh inside the existing Warmane tab."
 }

--- a/scripts/gear-sync/uninstall-windows-task.ps1
+++ b/scripts/gear-sync/uninstall-windows-task.ps1
@@ -6,7 +6,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 $schtasks = "schtasks.exe"
-$startupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGearSyncAtLogon.cmd"
+$startupScriptPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGearSyncAtLogon.vbs"
+$legacyStartupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGearSyncAtLogon.cmd"
 $removed = 0
 $found = 0
 
@@ -30,15 +31,17 @@ if ($queryExitCode -eq 0) {
   }
 }
 
-if (Test-Path -LiteralPath $startupCommandPath) {
-  $found++
-  if ($PSCmdlet.ShouldProcess($startupCommandPath, "Remove Pizza Logs Gear Sync startup launcher")) {
-    Remove-Item -LiteralPath $startupCommandPath -Force
-    Write-Host "Removed startup launcher '$startupCommandPath'."
-    $removed++
+foreach ($startupPath in @($startupScriptPath, $legacyStartupCommandPath)) {
+  if (Test-Path -LiteralPath $startupPath) {
+    $found++
+    if ($PSCmdlet.ShouldProcess($startupPath, "Remove Pizza Logs Gear Sync startup launcher")) {
+      Remove-Item -LiteralPath $startupPath -Force
+      Write-Host "Removed startup launcher '$startupPath'."
+      $removed++
+    }
   }
 }
 
 if ($found -eq 0) {
-  Write-Host "No scheduled task named '$TaskName' or startup launcher '$startupCommandPath' exists."
+  Write-Host "No scheduled task named '$TaskName' or startup launcher exists."
 }

--- a/scripts/guild-roster-sync/install-windows-task.ps1
+++ b/scripts/guild-roster-sync/install-windows-task.ps1
@@ -2,8 +2,6 @@
 param(
   [string]$TaskName = "PizzaLogsGuildRosterSync",
   [string]$TargetUrl = "https://armory.warmane.com/guild/Pizza+Warriors/Lordaeron/summary",
-  [int]$IntervalMinutes = 60,
-  [int]$StartDelayMinutes = 8,
   [string]$BrowserPath = "",
   [switch]$UseDefaultBrowser,
   [switch]$RunNow
@@ -11,17 +9,15 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-if ($IntervalMinutes -lt 15) {
-  throw "IntervalMinutes must be at least 15."
-}
-
 $launcherPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "open-warmane-guild-roster-sync.ps1")).Path
-$startAt = (Get-Date).AddMinutes($StartDelayMinutes).ToString("HH:mm")
 $startupFolder = [Environment]::GetFolderPath("Startup")
-$startupCommandPath = Join-Path $startupFolder "PizzaLogsGuildRosterSyncAtLogon.cmd"
+$startupScriptPath = Join-Path $startupFolder "PizzaLogsGuildRosterSyncAtLogon.vbs"
+$legacyStartupCommandPath = Join-Path $startupFolder "PizzaLogsGuildRosterSyncAtLogon.cmd"
 
 $taskArguments = @(
   "-NoProfile",
+  "-WindowStyle",
+  "Hidden",
   "-ExecutionPolicy",
   "Bypass",
   "-File",
@@ -41,6 +37,17 @@ if ($UseDefaultBrowser) {
 $taskCommand = "powershell.exe $($taskArguments -join ' ')"
 $schtasks = "schtasks.exe"
 
+function Test-ExistingTask {
+  $previousErrorActionPreference = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  try {
+    & $schtasks /Query /TN $TaskName > $null 2>&1
+    return $LASTEXITCODE -eq 0
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+}
+
 function Invoke-Schtasks {
   param([string[]]$Arguments)
 
@@ -50,28 +57,40 @@ function Invoke-Schtasks {
   }
 }
 
-if ($PSCmdlet.ShouldProcess($TaskName, "Register hourly Pizza Logs Guild Roster Sync scheduled task")) {
-  Invoke-Schtasks @(
-    "/Create",
-    "/TN", $TaskName,
-    "/SC", "MINUTE",
-    "/MO", "$IntervalMinutes",
-    "/ST", $startAt,
-    "/TR", $taskCommand,
-    "/F"
-  )
+function Remove-ExistingTask {
+  if (Test-ExistingTask) {
+    if ($PSCmdlet.ShouldProcess($TaskName, "Delete old hourly Pizza Logs Guild Roster Sync scheduled task")) {
+      Invoke-Schtasks @("/Delete", "/TN", $TaskName, "/F")
+      Write-Host "Removed old scheduled task '$TaskName'."
+    }
+  }
+}
 
-  Set-Content -LiteralPath $startupCommandPath -Value @(
-    "@echo off",
-    $taskCommand
+function ConvertTo-VbsStringLiteral {
+  param([string]$Value)
+  $escaped = $Value.Replace('"', '""')
+  return "`"$escaped`""
+}
+
+if ($PSCmdlet.ShouldProcess($startupScriptPath, "Create quiet Pizza Logs Guild Roster Sync startup launcher")) {
+  Remove-ExistingTask
+
+  if (Test-Path -LiteralPath $legacyStartupCommandPath) {
+    Remove-Item -LiteralPath $legacyStartupCommandPath -Force
+    Write-Host "Removed legacy startup launcher '$legacyStartupCommandPath'."
+  }
+
+  $vbsCommand = ConvertTo-VbsStringLiteral $taskCommand
+  Set-Content -LiteralPath $startupScriptPath -Value @(
+    'Set shell = CreateObject("WScript.Shell")',
+    "shell.Run $vbsCommand, 0, False"
   ) -Encoding ascii
 
   if ($RunNow) {
-    Invoke-Schtasks @("/Run", "/TN", $TaskName)
+    Start-Process -FilePath "powershell.exe" -ArgumentList $taskArguments -WindowStyle Hidden
   }
 
-  Write-Host "Registered scheduled task '$TaskName'."
-  Write-Host "Created startup launcher '$startupCommandPath'."
+  Write-Host "Created quiet startup launcher '$startupScriptPath'."
   Write-Host "Target URL: $TargetUrl"
-  Write-Host "Interval: every $IntervalMinutes minutes, plus at logon."
+  Write-Host "The browser userscript now owns the hourly refresh inside the existing Warmane tab."
 }

--- a/scripts/guild-roster-sync/uninstall-windows-task.ps1
+++ b/scripts/guild-roster-sync/uninstall-windows-task.ps1
@@ -6,7 +6,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 $schtasks = "schtasks.exe"
-$startupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGuildRosterSyncAtLogon.cmd"
+$startupScriptPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGuildRosterSyncAtLogon.vbs"
+$legacyStartupCommandPath = Join-Path ([Environment]::GetFolderPath("Startup")) "PizzaLogsGuildRosterSyncAtLogon.cmd"
 $removed = 0
 $found = 0
 
@@ -30,15 +31,17 @@ if ($queryExitCode -eq 0) {
   }
 }
 
-if (Test-Path -LiteralPath $startupCommandPath) {
-  $found++
-  if ($PSCmdlet.ShouldProcess($startupCommandPath, "Remove Pizza Logs Guild Roster Sync startup launcher")) {
-    Remove-Item -LiteralPath $startupCommandPath -Force
-    Write-Host "Removed startup launcher '$startupCommandPath'."
-    $removed++
+foreach ($startupPath in @($startupScriptPath, $legacyStartupCommandPath)) {
+  if (Test-Path -LiteralPath $startupPath) {
+    $found++
+    if ($PSCmdlet.ShouldProcess($startupPath, "Remove Pizza Logs Guild Roster Sync startup launcher")) {
+      Remove-Item -LiteralPath $startupPath -Force
+      Write-Host "Removed startup launcher '$startupPath'."
+      $removed++
+    }
   }
 }
 
 if ($found -eq 0) {
-  Write-Host "No scheduled task named '$TaskName' or startup launcher '$startupCommandPath' exists."
+  Write-Host "No scheduled task named '$TaskName' or startup launcher exists."
 }

--- a/tests/armory-gear-client-scripts.test.ts
+++ b/tests/armory-gear-client-scripts.test.ts
@@ -36,7 +36,7 @@ assert.match(localUserscript, new RegExp(`// @downloadURL\\s+${LOCAL_USERSCRIPT_
 assert.match(localUserscript, new RegExp(`// @updateURL\\s+${LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 assert.match(localUserscript, new RegExp(`const pizzaLogsOrigin = "${PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}";`));
 assert.match(localUserscript, /\/api\/admin\/armory-gear\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.8\.0/);
+assert.match(userscript, /\/\/ @version\s+1\.8\.1/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/character\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/character\/\*/);
 assert.match(userscript, new RegExp(`pizzaLogsAdminSecret:${PIZZA_LOGS_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
@@ -58,6 +58,9 @@ assert.match(userscript, /Pizza Logs panel injection failed/);
 assert.match(userscript, /Pizza Logs Gear Sync/);
 assert.match(userscript, /Refreshing known Pizza Logs players/);
 assert.match(userscript, /mode: "refresh-all"/);
+assert.match(userscript, /scheduleNextAutoSync/);
+assert.match(userscript, /autoTimer/);
+assert.match(userscript, /clearTimeout/);
 assert.match(bookmarklet, /mode: "refresh-all"/);
 assert.match(bookmarklet, /no Pizza Logs players found to refresh/i);
 
@@ -90,13 +93,15 @@ async function verifyUserscriptMergesDomIconFallback() {
       removeItem: (key: string) => storage.delete(key),
     },
     prompt: () => "secret",
-    setTimeout: (callback: () => unknown) => {
+    setTimeout: (callback: () => unknown, delay?: number) => {
+      if (typeof delay === "number" && delay > 5000) return 1;
       const result = callback();
       if (result && typeof (result as Promise<unknown>).then === "function") {
         pending.push(result as Promise<unknown>);
       }
       return 1;
     },
+    clearTimeout() {},
     document: {
       body: { appendChild() {} },
       addEventListener() {},
@@ -183,13 +188,15 @@ async function verifyUserscriptFetchesQueuedPlayerPageIcons() {
       removeItem: (key: string) => storage.delete(key),
     },
     prompt: () => "secret",
-    setTimeout: (callback: () => unknown) => {
+    setTimeout: (callback: () => unknown, delay?: number) => {
+      if (typeof delay === "number" && delay > 5000) return 1;
       const result = callback();
       if (result && typeof (result as Promise<unknown>).then === "function") {
         pending.push(result as Promise<unknown>);
       }
       return 1;
     },
+    clearTimeout() {},
     DOMParser: class {
       parseFromString() {
         return makeIconDocument();

--- a/tests/gear-import-bookmarklet.test.ts
+++ b/tests/gear-import-bookmarklet.test.ts
@@ -8,6 +8,7 @@ const markup = renderToStaticMarkup(React.createElement(GearImportBookmarklet));
 
 assert.match(markup, /Browser Gear Import/);
 assert.match(markup, /refreshes every known Pizza Logs character once per hour/);
+assert.match(markup, /reuse that tab for hourly sync/);
 assert.match(markup, new RegExp(USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 assert.match(markup, new RegExp(LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 assert.match(markup, /Install \/ Update Gear Userscript/);

--- a/tests/gear-sync-windows-task-source.test.ts
+++ b/tests/gear-sync-windows-task-source.test.ts
@@ -18,16 +18,22 @@ assert.match(launcher, /Warmane Gear Sync userscript/i);
 
 assert.match(installer, /PizzaLogsGearSync/);
 assert.match(installer, /schtasks\.exe/i);
-assert.match(installer, /\/SC"\s*,\s*"MINUTE"/);
 assert.match(installer, /GetFolderPath\("Startup"\)/);
+assert.match(installer, /PizzaLogsGearSyncAtLogon\.vbs/);
 assert.match(installer, /PizzaLogsGearSyncAtLogon\.cmd/);
 assert.match(installer, /open-warmane-gear-sync\.ps1/);
+assert.match(installer, /WindowStyle Hidden/);
+assert.match(installer, /WScript\.Shell/);
+assert.match(installer, /Remove-ExistingTask/);
+assert.match(installer, /\$escaped = \$Value\.Replace/);
+assert.doesNotMatch(installer, /\/SC"\s*,\s*"MINUTE"/);
 assert.doesNotMatch(installer, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
 
 assert.match(uninstaller, /schtasks\.exe/i);
 assert.match(uninstaller, /\/Delete/);
 assert.match(uninstaller, /PizzaLogsGearSync/);
 assert.match(uninstaller, /PizzaLogsGearSyncAtLogon\.cmd/);
+assert.match(uninstaller, /PizzaLogsGearSyncAtLogon\.vbs/);
 assert.match(uninstaller, /queryExitCode/);
 assert.doesNotMatch(uninstaller, /\*>\s*\$null/);
 assert.doesNotMatch(uninstaller, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
@@ -36,6 +42,8 @@ assert.match(docs, /does not store the Pizza Logs admin secret/i);
 assert.match(docs, /Tampermonkey/i);
 assert.match(docs, /persists through restarts/i);
 assert.match(docs, /Startup folder/i);
+assert.match(docs, /existing Warmane tab/i);
+assert.match(docs, /does not create a new browser tab every hour/i);
 assert.match(docs, /\.sync-agent-logs/);
 
 assert.equal(

--- a/tests/guild-roster-admin-panel.test.ts
+++ b/tests/guild-roster-admin-panel.test.ts
@@ -16,6 +16,7 @@ assert.match(markup, /42/);
 assert.match(markup, /Warmane/);
 assert.match(markup, /Browser Roster Import/);
 assert.match(markup, /auto-sync the roster hourly/);
+assert.match(markup, /Warmane tab can keep auto-syncing/);
 assert.match(markup, /userscript\.user\.js/);
 assert.match(markup, /Install Local Roster Userscript/);
 assert.match(markup, new RegExp(LOCAL_GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));

--- a/tests/guild-roster-client-scripts.test.ts
+++ b/tests/guild-roster-client-scripts.test.ts
@@ -16,12 +16,15 @@ const localUserscript = buildGuildRosterUserscript({
 });
 assert.match(userscript, /Pizza Logs Warmane Guild Roster Sync/);
 assert.match(userscript, /api\/admin\/guild-roster\/import/);
-assert.match(userscript, /\/\/ @version\s+1\.1\.0/);
+assert.match(userscript, /\/\/ @version\s+1\.1\.1/);
 assert.match(userscript, /\/\/ @match\s+https:\/\/armory\.warmane\.com\/guild\/\*/);
 assert.match(userscript, /\/\/ @match\s+http:\/\/armory\.warmane\.com\/guild\/\*/);
 assert.match(userscript, /pizzaLogsAdminSecret:https:\/\/pizza-logs-production\.up\.railway\.app/);
 assert.match(userscript, /pizzaLogsLastRosterSyncAt:https:\/\/pizza-logs-production\.up\.railway\.app/);
 assert.match(userscript, /autoIntervalMs = 60 \* 60 \* 1000/);
+assert.match(userscript, /scheduleNextAutoSync/);
+assert.match(userscript, /autoTimer/);
+assert.match(userscript, /clearTimeout/);
 assert.match(userscript, /isGuildPage/);
 assert.match(userscript, /api\/guild\/Pizza\+Warriors\/Lordaeron\/summary/);
 assert.match(userscript, /guild\/Pizza\+Warriors\/Lordaeron\/summary/);
@@ -68,13 +71,15 @@ async function verifyUserscriptAutoRunsWithSavedSecret() {
     prompt: () => {
       throw new Error("Auto-sync should use the saved secret");
     },
-    setTimeout: (callback: () => unknown) => {
+    setTimeout: (callback: () => unknown, delay?: number) => {
+      if (typeof delay === "number" && delay > 5000) return 1;
       const result = callback();
       if (result && typeof (result as Promise<unknown>).then === "function") {
         pending.push(result as Promise<unknown>);
       }
       return 1;
     },
+    clearTimeout() {},
     document: {
       body: { appendChild() {} },
       addEventListener() {},

--- a/tests/guild-roster-sync-windows-task-source.test.ts
+++ b/tests/guild-roster-sync-windows-task-source.test.ts
@@ -19,16 +19,22 @@ assert.match(launcher, /\/guild\/\[\^\/\]\+\/\[\^\/\]\+\/summary/);
 
 assert.match(installer, /PizzaLogsGuildRosterSync/);
 assert.match(installer, /schtasks\.exe/i);
-assert.match(installer, /\/SC"\s*,\s*"MINUTE"/);
 assert.match(installer, /GetFolderPath\("Startup"\)/);
+assert.match(installer, /PizzaLogsGuildRosterSyncAtLogon\.vbs/);
 assert.match(installer, /PizzaLogsGuildRosterSyncAtLogon\.cmd/);
 assert.match(installer, /open-warmane-guild-roster-sync\.ps1/);
+assert.match(installer, /WindowStyle Hidden/);
+assert.match(installer, /WScript\.Shell/);
+assert.match(installer, /Remove-ExistingTask/);
+assert.match(installer, /\$escaped = \$Value\.Replace/);
+assert.doesNotMatch(installer, /\/SC"\s*,\s*"MINUTE"/);
 assert.doesNotMatch(installer, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
 
 assert.match(uninstaller, /schtasks\.exe/i);
 assert.match(uninstaller, /\/Delete/);
 assert.match(uninstaller, /PizzaLogsGuildRosterSync/);
 assert.match(uninstaller, /PizzaLogsGuildRosterSyncAtLogon\.cmd/);
+assert.match(uninstaller, /PizzaLogsGuildRosterSyncAtLogon\.vbs/);
 assert.match(uninstaller, /queryExitCode/);
 assert.doesNotMatch(uninstaller, /\*>\s*\$null/);
 assert.doesNotMatch(uninstaller, /ADMIN_SECRET|DATABASE_URL|RAILWAY_TOKEN/);
@@ -37,6 +43,8 @@ assert.match(docs, /does not store the Pizza Logs admin secret/i);
 assert.match(docs, /Tampermonkey/i);
 assert.match(docs, /persists through restarts/i);
 assert.match(docs, /Startup folder/i);
+assert.match(docs, /existing Warmane tab/i);
+assert.match(docs, /does not create a new browser tab every hour/i);
 assert.match(docs, /guild-roster-sync-launcher\.log/);
 
 assert.equal(

--- a/tests/local-userscript-routes.test.ts
+++ b/tests/local-userscript-routes.test.ts
@@ -48,11 +48,12 @@ async function main() {
   const portrait = await readLocalUserscript("../app/api/player-portraits/userscript.local.user.js/route");
 
   assert.match(gear, /Pizza Logs Warmane Gear Auto Sync \(Local\)/);
+  assert.match(gear, /\/\/ @version\s+1\.8\.1/);
   assert.match(gear, new RegExp(LOCAL_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(gear, new RegExp(PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 
   assert.match(roster, /Pizza Logs Warmane Guild Roster Sync \(Local\)/);
-  assert.match(roster, /\/\/ @version\s+1\.1\.0/);
+  assert.match(roster, /\/\/ @version\s+1\.1\.1/);
   assert.match(roster, new RegExp(LOCAL_GUILD_ROSTER_USERSCRIPT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(roster, new RegExp(PIZZA_LOGS_LOCAL_ORIGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 


### PR DESCRIPTION
## Summary
- move gear and roster hourly refresh ownership into the Warmane userscripts so an existing tab keeps syncing without Windows opening a new tab every hour
- replace visible Startup `.cmd` launchers with hidden `.vbs` wrappers using `powershell.exe -WindowStyle Hidden`
- update installers to remove the old hourly `PizzaLogsGearSync` / `PizzaLogsGuildRosterSync` scheduled tasks and clean up legacy `.cmd` files

## Local Windows update applied
- removed `PizzaLogsGearSync` scheduled task
- removed `PizzaLogsGuildRosterSync` scheduled task
- removed old Startup `.cmd` launchers
- created `PizzaLogsGearSyncAtLogon.vbs`
- created `PizzaLogsGuildRosterSyncAtLogon.vbs`

## Validation
- npx ts-node --project tsconfig.seed.json tests\armory-gear-client-scripts.test.ts
- npx ts-node --project tsconfig.seed.json tests\guild-roster-client-scripts.test.ts
- npx ts-node --project tsconfig.seed.json tests\gear-sync-windows-task-source.test.ts
- npx ts-node --project tsconfig.seed.json tests\guild-roster-sync-windows-task-source.test.ts
- npx ts-node --project tsconfig.seed.json tests\local-userscript-routes.test.ts
- npx ts-node --project tsconfig.seed.json --compiler-options '{"jsx":"react-jsx"}' tests\gear-import-bookmarklet.test.ts
- npx ts-node --project tsconfig.seed.json --compiler-options '{"jsx":"react-jsx"}' tests\guild-roster-admin-panel.test.ts
- npm run type-check
- npm run lint
- npm run build
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\gear-sync\install-windows-task.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\guild-roster-sync\install-windows-task.ps1
- schtasks.exe /Query /TN PizzaLogsGearSync confirmed absent
- schtasks.exe /Query /TN PizzaLogsGuildRosterSync confirmed absent
- Startup VBS content checked for escaped script paths and `-WindowStyle Hidden`

## Notes
- This avoids recurring tab creation by keeping hourly refreshes inside an already-open Warmane tab.
- If the Warmane tab is closed, sync resumes after the tab is opened again or after the next Windows logon launcher opens it.